### PR TITLE
adjustments to run in .NET Framework, adding job to run tests for .NET Framework

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,19 @@ env:
 
 jobs:
 
+  windows:
+    name: windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: run redis-stack-server docker
+        run: docker run -p 6379:6379 -d redis/redis-stack-server:edge
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
+      - name: Test
+        run: dotnet test --no-build --verbosity normal -f net481
   build_and_test:
     name: Build and test
     runs-on: ubuntu-latest
@@ -35,8 +48,10 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
+        - name: Test
+        run: dotnet test -f net6.0 --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
       - name: Test
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+        run: dotnet test -f net7.0 --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/src/NRedisStack/ResponseParser.cs
+++ b/src/NRedisStack/ResponseParser.cs
@@ -47,6 +47,8 @@ namespace NRedisStack
 
         public static double ToDouble(this RedisResult result)
         {
+            if (result.ToString() == "nan")
+                return double.NaN;
             if ((double?)result == null)
                 throw new ArgumentNullException(nameof(result));
             return (double)result;

--- a/src/NRedisStack/Tdigest/TdigestCommands.cs
+++ b/src/NRedisStack/Tdigest/TdigestCommands.cs
@@ -44,7 +44,9 @@ namespace NRedisStack
         /// <inheritdoc/>
         public double Min(RedisKey key)
         {
-            return _db.Execute(TdigestCommandBuilder.Min(key)).ToDouble();
+            var cmd = TdigestCommandBuilder.Min(key);
+            var res =_db.Execute(cmd);
+            return res.ToDouble();
         }
 
         /// <inheritdoc/>

--- a/tests/NRedisStack.Tests/NRedisStack.Tests.csproj
+++ b/tests/NRedisStack.Tests/NRedisStack.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net462</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/NRedisStack.Tests/Tdigest/TdigestTests.cs
+++ b/tests/NRedisStack.Tests/Tdigest/TdigestTests.cs
@@ -666,7 +666,7 @@ public class TdigestTests : AbstractNRedisStackTest, IDisposable
     {
         Random random = new Random();
 
-        return new Tuple<double, long>(random.NextDouble() * 10000, random.NextInt64() + 1);
+        return new Tuple<double, long>(random.NextDouble() * 10000, random.Next() + 1);
     }
 
     static Tuple<double, long>[] RandomValueWeightArray(int count)
@@ -687,7 +687,11 @@ public class TdigestTests : AbstractNRedisStackTest, IDisposable
     private static double[] WeightedValue(double value, int weight)
     {
         double[] values = new double[weight];
-        Array.Fill(values, value);
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = value;
+        }
+
         return values;
     }
 }

--- a/tests/NRedisStack.Tests/TimeSeries/TestAPI/TestMADD.cs
+++ b/tests/NRedisStack.Tests/TimeSeries/TestAPI/TestMADD.cs
@@ -1,4 +1,5 @@
 ﻿using NRedisStack.DataTypes;
+using NRedisStack.Literals.Enums;
 using NRedisStack.RedisStackCommands;
 using StackExchange.Redis;
 using Xunit;
@@ -88,7 +89,7 @@ namespace NRedisStack.Tests.TimeSeries.TestAPI
 
             foreach (string key in keys)
             {
-                ts.Create(key);
+                ts.Create(key, duplicatePolicy: TsDuplicatePolicy.MAX);
             }
 
             List<DateTime> oldTimeStamps = new List<DateTime>();

--- a/tests/NRedisStack.Tests/TimeSeries/TestAPI/TestMAddAsync.cs
+++ b/tests/NRedisStack.Tests/TimeSeries/TestAPI/TestMAddAsync.cs
@@ -1,4 +1,5 @@
 ﻿using NRedisStack.DataTypes;
+using NRedisStack.Literals.Enums;
 using NRedisStack.RedisStackCommands;
 using StackExchange.Redis;
 using Xunit;
@@ -82,7 +83,7 @@ namespace NRedisStack.Tests.TimeSeries.TestAPI
 
             foreach (var key in keys)
             {
-                await ts.CreateAsync(key);
+                await ts.CreateAsync(key, duplicatePolicy: TsDuplicatePolicy.MAX);
             }
 
             var oldTimeStamps = new List<DateTime>();


### PR DESCRIPTION
Needed to make a couple updates to get this to work with .NET Framework

1. Array.Fill doesn't exist in .NET Framework - so needed to replicate the behavior
2. Random.NextInt64 doesn't exist in .NET Framework - I squeezed it into a simple Random.Next (which produces an in32 instead of an int64) - if an Int64 is really needed - we can do that (would just need to produce 2 Int32s and do a bit shift and bitwise or)
3. Casting "nan" to a double apparently doesn't work outside of .NET Core, trying to do so will result in a weird casting exception - fundamentally caused by `System.Format` not checking for `nan` This might be something to take upstream to StackExchange.Redis - but I cannot think of a non-module command that returns a `nan` so IMO it is, for the moment, something best managed by the derived library.
4. The `MADD` tests were adding the same timestamp over and over without setting a proper duplication policy - you might have a better sense as to why this would have worked at all, but I made the adjustment to set them right by sending a non `NO_DUPLICATE` duplication policy.