### PR TITLE
Simple documentation examples as test cases

### DIFF
--- a/NRedisStack.sln
+++ b/NRedisStack.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NRedisStack", "src\NRedisSt
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NRedisStack.Tests", "tests\NRedisStack.Tests\NRedisStack.Tests.csproj", "{73B56C35-BC92-4ACD-B077-7D55CD67B95F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doc", "tests\Doc\Doc.csproj", "{F14F6342-14A0-4DDD-AB05-C425B1AD8001}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{73B56C35-BC92-4ACD-B077-7D55CD67B95F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{73B56C35-BC92-4ACD-B077-7D55CD67B95F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73B56C35-BC92-4ACD-B077-7D55CD67B95F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F14F6342-14A0-4DDD-AB05-C425B1AD8001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F14F6342-14A0-4DDD-AB05-C425B1AD8001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F14F6342-14A0-4DDD-AB05-C425B1AD8001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F14F6342-14A0-4DDD-AB05-C425B1AD8001}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/tests/Doc/.gitignore
+++ b/tests/Doc/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+Doc.sln
+.DS_Store

--- a/tests/Doc/Doc.csproj
+++ b/tests/Doc/Doc.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks Condition=" '$(IsWindows)' != 'true'">net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+
 
     <IsPackable>false</IsPackable>
     <OutputType>Module</OutputType>

--- a/tests/Doc/Doc.csproj
+++ b/tests/Doc/Doc.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <OutputType>Module</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StackExchange.Redis" Version="2.6.104" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Doc/Doc.csproj
+++ b/tests/Doc/Doc.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <IsWindows>$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::get_Windows())))</IsWindows>
+    <TargetFrameworks Condition=" '$(IsWindows)' == 'true'">net6.0;net7.0;net481</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsWindows)' != 'true'">net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/Doc/SetGetExample.cs
+++ b/tests/Doc/SetGetExample.cs
@@ -1,0 +1,34 @@
+﻿// EXAMPLE: set_and_get
+// HIDE_START
+using System;
+using StackExchange.Redis;
+
+namespace NRedisStack.Doc;
+
+public class SetGetExample
+{
+    [Fact]
+    public void run()
+    {
+        var redis = ConnectionMultiplexer.Connect("localhost:6379");
+        var db = redis.GetDatabase();
+
+        //HIDE_END
+        bool status = db.StringSet("bike:1", "Process 134");
+            
+        if (status)
+            Console.WriteLine("Successfully added a bike.");
+
+        var value = db.StringGet("bike:1");
+
+        if (value.HasValue)
+            Console.WriteLine("The name of the bike is: " + value + ".");
+
+        //REMOVE_START
+        Assert.True(status);
+        Assert.Equal("Process 134", value.ToString());
+        //REMOVE_END
+    //HIDE_START
+    }
+}
+//HIDE_END

--- a/tests/Doc/Usings.cs
+++ b/tests/Doc/Usings.cs
@@ -1,0 +1,3 @@
+﻿global using Xunit;
+global using Xunit.Abstractions;
+


### PR DESCRIPTION
Hello,

this pull request adds an additional test project to the existing NRedisStack solution.

The idea is that the files in this project will be pulled for code examples within the documentation on redis.io. It would be good to run this test project on a regular basis for new versions of NRedisStack in order to ensure that the documentation examples are functional.

In the sake of the example, we tried to minimize the surrounding code as much as possible. This includes, for instance:

* A simple but not too abstract way of establishing the connection
* A neutral method name (e.g., `run`)
* Minimal error handling
* Blocks of code that are 'by default hidden' (`HIDE_START` ... `HIDE_END`) or entirely hidden (`REMOVE_START` ... `REMOVE_END`) within the documentation.
* The `[Fact]` test annotation will not be visible in the documentation.

Regards,
David
