### PR TITLE
Ability to specify test host and port

### DIFF
--- a/tests/NRedisStack.Tests/Examples/ExamplesTests.cs
+++ b/tests/NRedisStack.Tests/Examples/ExamplesTests.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Moq;
 using NRedisStack.DataTypes;
 using NRedisStack.RedisStackCommands;
@@ -26,10 +25,11 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     public void HSETandSearch()
     {
         // Connect to the Redis server
-        var redis = ConnectionMultiplexer.Connect("localhost");
+        // var redis = ConnectionMultiplexer.Connect("localhost");
 
         // Get a reference to the database and for search commands:
-        var db = redis.GetDatabase();
+        // var db = redis.GetDatabase();
+        var db =  redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
         var ft = db.FT();
 
@@ -77,8 +77,9 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     public async Task AsyncExample()
     {
         // Connect to the Redis server
-        var redis = await ConnectionMultiplexer.ConnectAsync("localhost");
-        var db = redis.GetDatabase();
+        // var redis = await ConnectionMultiplexer.ConnectAsync("localhost");
+        // var db = redis.GetDatabase();
+        var db = redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
         var json = db.JSON();
 
@@ -169,10 +170,11 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     public async Task PipelineWithAsync()
     {
         // Connect to the Redis server
-        var redis = ConnectionMultiplexer.Connect("localhost");
+        // var redis = ConnectionMultiplexer.Connect("localhost");
 
         // Get a reference to the database
-        var db = redis.GetDatabase();
+        // var db = redis.GetDatabase();
+        var db =  redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
         // Setup pipeline connection
 
@@ -226,10 +228,12 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     public async Task TransactionExample()
     {
         // Connect to the Redis server
-        var redis = ConnectionMultiplexer.Connect("localhost");
+        // var redis = ConnectionMultiplexer.Connect("localhost");
 
         // Get a reference to the database
-        var db = redis.GetDatabase();
+        // var db = redis.GetDatabase();
+
+        var db = redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
 
         // Setup transaction with IDatabase
@@ -267,8 +271,10 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     [Fact]
     public void TestJsonConvert()
     {
-        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
-        IDatabase db = redis.GetDatabase();
+        // ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
+        // IDatabase db = redis.GetDatabase();
+
+        var db =  redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
         ISearchCommands ft = db.FT();
         IJsonCommands json = db.JSON();
@@ -289,8 +295,9 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     [Fact]
     public void BasicJsonExamplesTest()
     {
-        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
-        IDatabase db = redis.GetDatabase();
+        // ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
+        // IDatabase db = redis.GetDatabase();
+        var db =  redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
         IJsonCommands json = db.JSON();
 
@@ -543,8 +550,9 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     [Fact]
     public void AdvancedJsonExamplesTest()
     {
-        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
-        IDatabase db = redis.GetDatabase();
+        // ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
+        // IDatabase db = redis.GetDatabase();
+        var db =  redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
         IJsonCommands json = db.JSON();
 
@@ -676,8 +684,9 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     [Fact]
     public void BasicQueryOperationsTest()
     {
-        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
-        IDatabase db = redis.GetDatabase();
+        // ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
+        // IDatabase db = redis.GetDatabase();
+        var db =  redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
         IJsonCommands json = db.JSON();
         ISearchCommands ft = db.FT();
@@ -835,8 +844,9 @@ public class ExaplesTests : AbstractNRedisStackTest, IDisposable
     [Fact]
     public void AdvancedQueryOperationsTest()
     {
-        ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
-        IDatabase db = redis.GetDatabase();
+        // ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("localhost");
+        // IDatabase db = redis.GetDatabase();
+        var db =  redisFixture.Redis.GetDatabase();
         db.Execute("FLUSHALL");
         IJsonCommands json = db.JSON();
         ISearchCommands ft = db.FT();

--- a/tests/NRedisStack.Tests/Graph/GraphTests.cs
+++ b/tests/NRedisStack.Tests/Graph/GraphTests.cs
@@ -1924,29 +1924,6 @@ public class GraphTests : AbstractNRedisStackTest, IDisposable
     }
 
     [Fact]
-    public async Task TestModulePrefixs1Async()
-    {
-        {
-            var conn = ConnectionMultiplexer.Connect("localhost");
-            IDatabase db = conn.GetDatabase();
-
-            var graph = db.GRAPH();
-            // ...
-            conn.Dispose();
-        }
-
-        {
-            var conn = ConnectionMultiplexer.Connect("localhost");
-            IDatabase db = conn.GetDatabase();
-
-            var graph = db.GRAPH();
-            // ...
-            conn.Dispose();
-        }
-
-    }
-
-    [Fact]
     public void TestEqualsAndToString()
     {
         IDatabase db = redisFixture.Redis.GetDatabase();

--- a/tests/NRedisStack.Tests/RedisFixture.cs
+++ b/tests/NRedisStack.Tests/RedisFixture.cs
@@ -5,9 +5,10 @@ namespace NRedisStack.Tests
     public class RedisFixture : IDisposable
     {
 
-        string server = Environment.GetEnvironmentVariable("REDIS_SERVER") ?? "localhost";
-        string port = Environment.GetEnvironmentVariable("REDIS_PORT") ?? "6379";
-        public RedisFixture() => Redis = ConnectionMultiplexer.Connect($"{server}:{port}");
+
+        // Set the enviroment variable to specify your own alternet host and port:
+        string redis = Environment.GetEnvironmentVariable("REDIS") ?? "localhost:6379";
+        public RedisFixture() => Redis = ConnectionMultiplexer.Connect($"{redis}");
 
         public void Dispose()
         {

--- a/tests/NRedisStack.Tests/RedisFixture.cs
+++ b/tests/NRedisStack.Tests/RedisFixture.cs
@@ -4,7 +4,10 @@ namespace NRedisStack.Tests
 {
     public class RedisFixture : IDisposable
     {
-        public RedisFixture() => Redis = ConnectionMultiplexer.Connect("localhost");
+
+        string server = Environment.GetEnvironmentVariable("REDIS_SERVER") ?? "localhost";
+        string port = Environment.GetEnvironmentVariable("REDIS_PORT") ?? "6379";
+        public RedisFixture() => Redis = ConnectionMultiplexer.Connect($"{server}:{port}");
 
         public void Dispose()
         {


### PR DESCRIPTION
pattern:
```bash
dotnet test --environment="REDIS=<redisServer:port>"
```
e.g: 
```bash
dotnet test --environment="REDIS=172.17.0.1:6379"
```