### PR TITLE
Fix Explain & ExplainCli Query Input

### DIFF
--- a/src/NRedisStack/Search/AggregationRequest.cs
+++ b/src/NRedisStack/Search/AggregationRequest.cs
@@ -8,6 +8,10 @@ namespace NRedisStack.Search.Aggregation
         private bool isWithCursor = false;
 
         // Parameters:
+<<<<<<< HEAD
+=======
+        private int? dialect = 2; // Set default value to DIACLECT 2
+>>>>>>> ac447f1 (add SerializeRedisArgs for FT.AGGREGATE)
 
         private bool? verbatim = null;
 
@@ -61,6 +65,18 @@ namespace NRedisStack.Search.Aggregation
                 args.Add("VERBATIM");
         }
 
+        public AggregationRequest Verbatim(bool verbatim = true)
+        {
+            this.verbatim = true;
+            return this;
+        }
+
+        private void Verbatim()
+        {
+            if(verbatim == true)
+                args.Add("VERBATIM");
+        }
+
         public AggregationRequest Load(params FieldName[] fields)
         {
             this.fieldNames.AddRange(fields);
@@ -83,17 +99,26 @@ namespace NRedisStack.Search.Aggregation
             }
             else if (fieldNames.Count > 0)
             {
+<<<<<<< HEAD
                 args.Add("LOAD");
                 int loadCountIndex = args.Count;
                 //args.Add(null);
+=======
+                int loadCountIndex = args.Count;
+                args.Add(null);
+>>>>>>> ac447f1 (add SerializeRedisArgs for FT.AGGREGATE)
                 int loadCount = 0;
                 foreach (FieldName fn in fieldNames)
                 {
                     loadCount += fn.AddCommandArguments(args);
                 }
+<<<<<<< HEAD
 
                 args.Insert(loadCountIndex, loadCount);
                 // args[loadCountIndex] = loadCount.ToString();
+=======
+                args.Insert(loadCountIndex, loadCount.ToString());
+>>>>>>> ac447f1 (add SerializeRedisArgs for FT.AGGREGATE)
             }
         }
 
@@ -163,7 +188,11 @@ namespace NRedisStack.Search.Aggregation
                 foreach (SortedField field in sortedFields)
                 {
                     args.Add(field.FieldName);
+<<<<<<< HEAD
                     args.Add(field.Order.ToString());
+=======
+                    args.Add(field.Order);
+>>>>>>> ac447f1 (add SerializeRedisArgs for FT.AGGREGATE)
                 }
 
                 if (max > 0)
@@ -313,9 +342,15 @@ namespace NRedisStack.Search.Aggregation
             Verbatim();
             Load();
             Timeout();
+<<<<<<< HEAD
             Apply();
             GroupBy();
             SortBy();
+=======
+            GroupBy();
+            SortBy();
+            Apply();
+>>>>>>> ac447f1 (add SerializeRedisArgs for FT.AGGREGATE)
             Limit();
             Filter();
             Cursor();

--- a/src/NRedisStack/Search/ISearchCommands.cs
+++ b/src/NRedisStack/Search/ISearchCommands.cs
@@ -146,19 +146,21 @@ namespace NRedisStack
         /// Return the execution plan for a complex query
         /// </summary>
         /// <param name="indexName">The index name</param>
-        /// <param name="q">The query to explain</param>
+        /// <param name="query">The query to explain</param>
+        /// <param name="dialect">Dialect version under which to execute the query</param>
         /// <returns>String that representing the execution plan</returns>
         /// <remarks><seealso href="https://redis.io/commands/ft.explain/"/></remarks>
-        string Explain(string indexName, Query q);
+        string Explain(string indexName, string query, int? dialect = null);
 
         /// <summary>
         /// Return the execution plan for a complex query
         /// </summary>
         /// <param name="indexName">The index name</param>
-        /// <param name="q">The query to explain</param>
+        /// <param name="query">The query to explain</param>
+        /// <param name="dialect">Dialect version under which to execute the query</param>
         /// <returns>An array reply with a string representing the execution plan</returns>
         /// <remarks><seealso href="https://redis.io/commands/ft.explaincli/"/></remarks>
-        RedisResult[] ExplainCli(string indexName, Query q);
+        RedisResult[] ExplainCli(string indexName, string query, int? dialect = null);
 
         /// <summary>
         /// Return information and statistics on the index.

--- a/src/NRedisStack/Search/ISearchCommandsAsync.cs
+++ b/src/NRedisStack/Search/ISearchCommandsAsync.cs
@@ -145,19 +145,21 @@ namespace NRedisStack
         /// Return the execution plan for a complex query
         /// </summary>
         /// <param name="indexName">The index name</param>
-        /// <param name="q">The query to explain</param>
+        /// <param name="query">The query to explain</param>
+        /// <param name="dialect">Dialect version under which to execute the query</param>
         /// <returns>String that representing the execution plan</returns>
         /// <remarks><seealso href="https://redis.io/commands/ft.explain/"/></remarks>
-        Task<string> ExplainAsync(string indexName, Query q);
+        Task<string> ExplainAsync(string indexName, string query, int? dialect = null);
 
         /// <summary>
         /// Return the execution plan for a complex query
         /// </summary>
         /// <param name="indexName">The index name</param>
-        /// <param name="q">The query to explain</param>
+        /// <param name="query">The query to explain</param>
+        /// <param name="dialect">Dialect version under which to execute the query</param>
         /// <returns>An array reply with a string representing the execution plan</returns>
         /// <remarks><seealso href="https://redis.io/commands/ft.explaincli/"/></remarks>
-        Task<RedisResult[]> ExplainCliAsync(string indexName, Query q);
+        Task<RedisResult[]> ExplainCliAsync(string indexName, string query, int? dialect = null);
 
         /// <summary>
         /// Return information and statistics on the index.

--- a/src/NRedisStack/Search/SearchCommandBuilder.cs
+++ b/src/NRedisStack/Search/SearchCommandBuilder.cs
@@ -126,17 +126,25 @@ namespace NRedisStack
                          : new SerializedCommand(FT.DROPINDEX, indexName));
         }
 
-        public static SerializedCommand Explain(string indexName, Query q)
+        public static SerializedCommand Explain(string indexName, string query, int? dialect)
         {
-            var args = new List<object> { indexName };
-            q.SerializeRedisArgs(args);
+            var args = new List<object> { indexName, query };
+            if (dialect != null)
+            {
+                args.Add("DIALECT");
+                args.Add(dialect);
+            }
             return new SerializedCommand(FT.EXPLAIN, args);
         }
 
-        public static SerializedCommand ExplainCli(string indexName, Query q)
+        public static SerializedCommand ExplainCli(string indexName, string query, int? dialect)
         {
-            var args = new List<object> { indexName };
-            q.SerializeRedisArgs(args);
+            var args = new List<object> { indexName, query };
+            if (dialect != null)
+            {
+                args.Add("DIALECT");
+                args.Add(dialect);
+            }
             return new SerializedCommand(FT.EXPLAINCLI, args);
         }
 

--- a/src/NRedisStack/Search/SearchCommands.cs
+++ b/src/NRedisStack/Search/SearchCommands.cs
@@ -130,23 +130,23 @@ namespace NRedisStack
         }
 
         /// <inheritdoc/>
-        public string Explain(string indexName, Query q)
+        public string Explain(string indexName, string query, int? dialect = null)
         {
-            if (q.dialect == null && defaultDialect != null)
+            if (dialect == null && defaultDialect != null)
             {
-                q.Dialect((int)defaultDialect);
+                dialect = defaultDialect;
             }
-            return _db.Execute(SearchCommandBuilder.Explain(indexName, q)).ToString();
+            return _db.Execute(SearchCommandBuilder.Explain(indexName, query, dialect)).ToString();
         }
 
         /// <inheritdoc/>
-        public RedisResult[] ExplainCli(string indexName, Query q)
+        public RedisResult[] ExplainCli(string indexName, string query, int? dialect = null)
         {
-            if (q.dialect == null && defaultDialect != null)
+            if (dialect == null && defaultDialect != null)
             {
-                q.Dialect((int)defaultDialect);
+                dialect = defaultDialect;
             }
-            return _db.Execute(SearchCommandBuilder.ExplainCli(indexName, q)).ToArray();
+            return _db.Execute(SearchCommandBuilder.ExplainCli(indexName, query, dialect)).ToArray();
         }
 
         /// <inheritdoc/>

--- a/src/NRedisStack/Search/SearchCommandsAsync.cs
+++ b/src/NRedisStack/Search/SearchCommandsAsync.cs
@@ -121,25 +121,25 @@ namespace NRedisStack
         }
 
         /// <inheritdoc/>
-        public async Task<string> ExplainAsync(string indexName, Query q)
+        public async Task<string> ExplainAsync(string indexName, string query, int? dialect = null)
         {
-            if (q.dialect == null && defaultDialect != null)
+            if (dialect == null && defaultDialect != null)
             {
-                q.Dialect((int)defaultDialect);
+                dialect = defaultDialect;
             }
 
-            return (await _db.ExecuteAsync(SearchCommandBuilder.Explain(indexName, q))).ToString();
+            return (await _db.ExecuteAsync(SearchCommandBuilder.Explain(indexName, query, dialect))).ToString();
         }
 
         /// <inheritdoc/>
-        public async Task<RedisResult[]> ExplainCliAsync(string indexName, Query q)
+        public async Task<RedisResult[]> ExplainCliAsync(string indexName, string query, int? dialect = null)
         {
-            if (q.dialect == null && defaultDialect != null)
+            if (dialect == null && defaultDialect != null)
             {
-                q.Dialect((int)defaultDialect);
+                dialect = defaultDialect;
             }
 
-            return (await _db.ExecuteAsync(SearchCommandBuilder.ExplainCli(indexName, q))).ToArray();
+            return (await _db.ExecuteAsync(SearchCommandBuilder.ExplainCli(indexName, query, dialect))).ToArray();
         }
 
         /// <inheritdoc/>

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -1329,9 +1329,16 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
             .AddTextField("f3", 1.0);
         ft.Create(index, FTCreateParams.CreateParams(), sc);
 
-        string res = ft.Explain(index, new Query("@f3:f3_val @f2:f2_val @f1:f1_val"));
+        string res = ft.Explain(index, "@f3:f3_val @f2:f2_val @f1:f1_val");
         Assert.NotNull(res);
         Assert.False(res.Length == 0);
+
+        // Test with dialect:
+        res = ft.Explain(index, "@f3:f3_val @f2:f2_val @f1:f1_val", 2);
+        Assert.NotNull(res);
+        Assert.False(res.Length == 0);
+
+
     }
 
     [Fact]
@@ -1346,7 +1353,12 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
             .AddTextField("f3", 1.0);
         ft.Create(index, FTCreateParams.CreateParams(), sc);
 
-        string res = await ft.ExplainAsync(index, new Query("@f3:f3_val @f2:f2_val @f1:f1_val"));
+        string res = await ft.ExplainAsync(index, "@f3:f3_val @f2:f2_val @f1:f1_val");
+        Assert.NotNull(res);
+        Assert.False(res.Length == 0);
+
+        // Test with dialect:
+        res = await ft.ExplainAsync(index, "@f3:f3_val @f2:f2_val @f1:f1_val", 2);
         Assert.NotNull(res);
         Assert.False(res.Length == 0);
     }
@@ -1363,7 +1375,12 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
             .AddTextField("f3", 1.0);
         ft.Create(index, FTCreateParams.CreateParams(), sc);
 
-        var res = ft.ExplainCli(index, new Query("@f3:f3_val @f2:f2_val @f1:f1_val"));
+        var res = ft.ExplainCli(index, "@f3:f3_val @f2:f2_val @f1:f1_val");
+        Assert.NotNull(res);
+        Assert.False(res.Length == 0);
+
+        // Test with dialect (ovveride the dialect 2):
+        res = ft.ExplainCli(index, "@f3:f3_val @f2:f2_val @f1:f1_val", 1);
         Assert.NotNull(res);
         Assert.False(res.Length == 0);
     }
@@ -1380,7 +1397,12 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
             .AddTextField("f3", 1.0);
         ft.Create(index, FTCreateParams.CreateParams(), sc);
 
-        var res = await ft.ExplainCliAsync(index, new Query("@f3:f3_val @f2:f2_val @f1:f1_val"));
+        var res = await ft.ExplainCliAsync(index, "@f3:f3_val @f2:f2_val @f1:f1_val");
+        Assert.NotNull(res);
+        Assert.False(res.Length == 0);
+
+        // Test with dialect (ovveride the dialect 2):
+        res = await ft.ExplainCliAsync(index, "@f3:f3_val @f2:f2_val @f1:f1_val", 1);
         Assert.NotNull(res);
         Assert.False(res.Length == 0);
     }
@@ -1397,7 +1419,7 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
             .AddTextField("f3", 1.0);
         ft.Create(index, FTCreateParams.CreateParams(), sc);
 
-        String res = ft.Explain(index, new Query("@f3:f3_val @f2:f2_val @f1:f1_val"));
+        String res = ft.Explain(index, "@f3:f3_val @f2:f2_val @f1:f1_val");
         Assert.NotNull(res);
         Assert.False(res.Length == 0);
     }
@@ -1414,7 +1436,7 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
             .AddTextField("f3", 1.0);
         ft.Create(index, FTCreateParams.CreateParams(), sc);
 
-        String res = await ft.ExplainAsync(index, new Query("@f3:f3_val @f2:f2_val @f1:f1_val"));
+        String res = await ft.ExplainAsync(index, "@f3:f3_val @f2:f2_val @f1:f1_val");
         Assert.NotNull(res);
         Assert.False(res.Length == 0);
     }


### PR DESCRIPTION
Currently, Explain and ExplainCli commands accept the Query class as input. Which made it possible to insert FT.SEARCH arguments as input to those commands.
In this PR I fixed it and now the commands receive a query of type string and not of type Query.