### PR TITLE
Introduce procedure mode selection for RedisGraph.

### DIFF
--- a/src/NRedisStack/Graph/GraphCacheList.cs
+++ b/src/NRedisStack/Graph/GraphCacheList.cs
@@ -5,12 +5,18 @@ namespace NRedisStack.Graph
         private readonly string _graphName;
         private readonly string _procedure;
 
-        private string[]? _data;
+        private string[] _data = Array.Empty<string>();
 
         private readonly GraphCommandsAsync _redisGraph;
 
         private readonly object _locker = new object();
 
+        /// <summary>
+        /// Constructs a <see cref="GraphCacheList"/> for providing cached information about the graph.
+        /// </summary>
+        /// <param name="graphName">The name of the graph to cache information for.</param>
+        /// <param name="procedure">The saved procedure to call to populate cache. Must be a `read` procedure.</param>
+        /// <param name="redisGraph">The graph used for the calling the <paramref name="procedure"/>.</param>
         internal GraphCacheList(string graphName, string procedure, GraphCommands redisGraph)
         {
             _graphName = graphName;
@@ -19,6 +25,12 @@ namespace NRedisStack.Graph
             _redisGraph = redisGraph;
         }
 
+        /// <summary>
+        /// Constructs a <see cref="GraphCacheList"/> for providing cached information about the graph.
+        /// </summary>
+        /// <param name="graphName">The name of the graph to cache information for.</param>
+        /// <param name="procedure">The saved procedure to call to populate cache. Must be a `read` procedure.</param>
+        /// <param name="redisGraph">The graph used for the calling the <paramref name="procedure"/>.</param>
         internal GraphCacheList(string graphName, string procedure, GraphCommandsAsync redisGraphAsync)
         {
             _graphName = graphName;
@@ -30,18 +42,18 @@ namespace NRedisStack.Graph
         // TODO: Change this to use Lazy<T>?
         internal string GetCachedData(int index)
         {
-            if (_data == null || index >= _data.Length)
+            if (index >= _data.Length)
             {
                 lock (_locker)
                 {
-                    if (_data == null || index >= _data.Length)
+                    if (index >= _data.Length)
                     {
                         _data = GetProcedureInfo();
                     }
                 }
             }
 
-            return _data?.ElementAtOrDefault(index) ?? string.Empty;
+            return _data.ElementAtOrDefault(index);
         }
 
         private string[] GetProcedureInfo()

--- a/src/NRedisStack/Graph/GraphCommands.cs
+++ b/src/NRedisStack/Graph/GraphCommands.cs
@@ -8,7 +8,7 @@ namespace NRedisStack
 {
     public class GraphCommands : GraphCommandsAsync, IGraphCommands
     {
-        IDatabase _db;
+        readonly IDatabase _db;
 
         public GraphCommands(IDatabase db) : base(db)
         {
@@ -55,17 +55,16 @@ namespace NRedisStack
             return new ResultSet(_db.Execute(GraphCommandBuilder.RO_Query(graphName, query, timeout)), _graphCaches[graphName]);
         }
 
-        internal static new readonly Dictionary<string, List<string>> EmptyKwargsDictionary =
+        private static readonly Dictionary<string, List<string>> EmptyKwargsDictionary =
             new Dictionary<string, List<string>>();
 
-        // TODO: Check if this is needed:
         /// <inheritdoc/>
         public ResultSet CallProcedure(string graphName, string procedure, ProcedureMode procedureMode = ProcedureMode.Write) =>
-        CallProcedure(graphName, procedure, Enumerable.Empty<string>(), EmptyKwargsDictionary, procedureMode);
+            CallProcedure(graphName, procedure, Enumerable.Empty<string>(), EmptyKwargsDictionary, procedureMode);
 
         /// <inheritdoc/>
         public ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, ProcedureMode procedureMode = ProcedureMode.Write) =>
-        CallProcedure(graphName, procedure, args, EmptyKwargsDictionary, procedureMode);
+            CallProcedure(graphName, procedure, args, EmptyKwargsDictionary, procedureMode);
 
         /// <inheritdoc/>
         public ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs, ProcedureMode procedureMode = ProcedureMode.Write)

--- a/src/NRedisStack/Graph/GraphCommands.cs
+++ b/src/NRedisStack/Graph/GraphCommands.cs
@@ -69,7 +69,7 @@ namespace NRedisStack
         /// <inheritdoc/>
         public ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs, ProcedureMode procedureMode = ProcedureMode.Write)
         {
-            args = args.Select(a => QuoteString(a));
+            args = args.Select(QuoteString);
 
             var queryBody = new StringBuilder();
 

--- a/src/NRedisStack/Graph/GraphCommands.cs
+++ b/src/NRedisStack/Graph/GraphCommands.cs
@@ -55,20 +55,20 @@ namespace NRedisStack
             return new ResultSet(_db.Execute(GraphCommandBuilder.RO_Query(graphName, query, timeout)), _graphCaches[graphName]);
         }
 
-        internal static readonly Dictionary<string, List<string>> EmptyKwargsDictionary =
+        internal static new readonly Dictionary<string, List<string>> EmptyKwargsDictionary =
             new Dictionary<string, List<string>>();
 
         // TODO: Check if this is needed:
         /// <inheritdoc/>
-        public ResultSet CallProcedure(string graphName, string procedure) =>
-        CallProcedure(graphName, procedure, Enumerable.Empty<string>(), EmptyKwargsDictionary);
+        public ResultSet CallProcedure(string graphName, string procedure, ProcedureMode procedureMode = ProcedureMode.Write) =>
+        CallProcedure(graphName, procedure, Enumerable.Empty<string>(), EmptyKwargsDictionary, procedureMode);
 
         /// <inheritdoc/>
-        public ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args) =>
-        CallProcedure(graphName, procedure, args, EmptyKwargsDictionary);
+        public ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, ProcedureMode procedureMode = ProcedureMode.Write) =>
+        CallProcedure(graphName, procedure, args, EmptyKwargsDictionary, procedureMode);
 
         /// <inheritdoc/>
-        public ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs)
+        public ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs, ProcedureMode procedureMode = ProcedureMode.Write)
         {
             args = args.Select(a => QuoteString(a));
 
@@ -81,7 +81,9 @@ namespace NRedisStack
                 queryBody.Append(string.Join(",", kwargsList));
             }
 
-            return Query(graphName, queryBody.ToString());
+            return procedureMode is ProcedureMode.Read
+                ? RO_Query(graphName, queryBody.ToString())
+                : Query(graphName, queryBody.ToString());
         }
 
         /// <inheritdoc/>

--- a/src/NRedisStack/Graph/GraphCommandsAsync.cs
+++ b/src/NRedisStack/Graph/GraphCommandsAsync.cs
@@ -59,19 +59,18 @@ namespace NRedisStack
         internal static readonly Dictionary<string, List<string>> EmptyKwargsDictionary =
             new Dictionary<string, List<string>>();
 
-        // TODO: Check if this is needed:
         /// <inheritdoc/>
-        public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure) =>
-        await CallProcedureAsync(graphName, procedure, Enumerable.Empty<string>(), EmptyKwargsDictionary);
+        public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure, ProcedureMode procedureMode = ProcedureMode.Write) =>
+        await CallProcedureAsync(graphName, procedure, Enumerable.Empty<string>(), EmptyKwargsDictionary, procedureMode);
 
         /// <inheritdoc/>
-        public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args) =>
-        await CallProcedureAsync(graphName, procedure, args, EmptyKwargsDictionary);
+        public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, ProcedureMode procedureMode = ProcedureMode.Write) =>
+        await CallProcedureAsync(graphName, procedure, args, EmptyKwargsDictionary, procedureMode);
 
         /// <inheritdoc/>
-        public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs)
+        public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs, ProcedureMode procedureMode = ProcedureMode.Write)
         {
-            args = args.Select(a => QuoteString(a));
+            args = args.Select(QuoteString);
 
             var queryBody = new StringBuilder();
 
@@ -82,7 +81,9 @@ namespace NRedisStack
                 queryBody.Append(string.Join(",", kwargsList));
             }
 
-            return await QueryAsync(graphName, queryBody.ToString());
+            return procedureMode is ProcedureMode.Read
+                ? await RO_QueryAsync(graphName, queryBody.ToString())
+                : await QueryAsync(graphName, queryBody.ToString());
         }
 
 

--- a/src/NRedisStack/Graph/GraphCommandsAsync.cs
+++ b/src/NRedisStack/Graph/GraphCommandsAsync.cs
@@ -9,7 +9,7 @@ namespace NRedisStack
 {
     public class GraphCommandsAsync : IGraphCommandsAsync
     {
-        IDatabaseAsync _db;
+        readonly IDatabaseAsync _db;
 
         public GraphCommandsAsync(IDatabaseAsync db)
         {
@@ -56,16 +56,16 @@ namespace NRedisStack
             return new ResultSet(await _db.ExecuteAsync(GraphCommandBuilder.RO_Query(graphName, query, timeout)), _graphCaches[graphName]);
         }
 
-        internal static readonly Dictionary<string, List<string>> EmptyKwargsDictionary =
+        private static readonly Dictionary<string, List<string>> EmptyKwargsDictionary =
             new Dictionary<string, List<string>>();
 
         /// <inheritdoc/>
-        public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure, ProcedureMode procedureMode = ProcedureMode.Write) =>
-        await CallProcedureAsync(graphName, procedure, Enumerable.Empty<string>(), EmptyKwargsDictionary, procedureMode);
+        public Task<ResultSet> CallProcedureAsync(string graphName, string procedure, ProcedureMode procedureMode = ProcedureMode.Write) =>
+            CallProcedureAsync(graphName, procedure, Enumerable.Empty<string>(), EmptyKwargsDictionary, procedureMode);
 
         /// <inheritdoc/>
-        public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, ProcedureMode procedureMode = ProcedureMode.Write) =>
-        await CallProcedureAsync(graphName, procedure, args, EmptyKwargsDictionary, procedureMode);
+        public Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, ProcedureMode procedureMode = ProcedureMode.Write) =>
+            CallProcedureAsync(graphName, procedure, args, EmptyKwargsDictionary, procedureMode);
 
         /// <inheritdoc/>
         public async Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs, ProcedureMode procedureMode = ProcedureMode.Write)

--- a/src/NRedisStack/Graph/IGraphCommands.cs
+++ b/src/NRedisStack/Graph/IGraphCommands.cs
@@ -53,8 +53,9 @@ namespace NRedisStack
         /// </summary>
         /// <param name="graphName">The graph containing the saved procedure.</param>
         /// <param name="procedure">The procedure name.</param>
+        /// <param name="procedureMode">The mode of the saved procedure. Defaults to <see cref="ProcedureMode.Write"/>.</param>
         /// <returns>A result set.</returns>
-        ResultSet CallProcedure(string graphName, string procedure);
+        ResultSet CallProcedure(string graphName, string procedure, ProcedureMode procedureMode = ProcedureMode.Write);
 
         /// <summary>
         /// Call a saved procedure with parameters.
@@ -62,8 +63,9 @@ namespace NRedisStack
         /// <param name="graphName">The graph containing the saved procedure.</param>
         /// <param name="procedure">The procedure name.</param>
         /// <param name="args">A collection of positional arguments.</param>
+        /// <param name="procedureMode">The mode of the saved procedure. Defaults to <see cref="ProcedureMode.Write"/>.</param>
         /// <returns>A result set.</returns>
-        ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args);
+        ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, ProcedureMode procedureMode = ProcedureMode.Write);
 
         /// <summary>
         /// Call a saved procedure with parameters.
@@ -72,8 +74,9 @@ namespace NRedisStack
         /// <param name="procedure">The procedure name.</param>
         /// <param name="args">A collection of positional arguments.</param>
         /// <param name="kwargs">A collection of keyword arguments.</param>
+        /// <param name="procedureMode">The mode of the saved procedure. Defaults to <see cref="ProcedureMode.Write"/>.</param>
         /// <returns>A result set.</returns>
-        ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs);
+        ResultSet CallProcedure(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs, ProcedureMode procedureMode = ProcedureMode.Write);
 
         /// <summary>
         /// Delete an existing graph.

--- a/src/NRedisStack/Graph/IGraphCommandsAsync.cs
+++ b/src/NRedisStack/Graph/IGraphCommandsAsync.cs
@@ -53,8 +53,9 @@ namespace NRedisStack
         /// </summary>
         /// <param name="graphName">The graph containing the saved procedure.</param>
         /// <param name="procedure">The procedure name.</param>
+        /// <param name="procedureMode">The mode of the saved procedure. Defaults to <see cref="ProcedureMode.Write"/>.</param>
         /// <returns>A result set.</returns>
-        Task<ResultSet> CallProcedureAsync(string graphName, string procedure);
+        Task<ResultSet> CallProcedureAsync(string graphName, string procedure, ProcedureMode procedureMode = ProcedureMode.Write);
 
         /// <summary>
         /// Call a saved procedure with parameters.
@@ -62,8 +63,9 @@ namespace NRedisStack
         /// <param name="graphName">The graph containing the saved procedure.</param>
         /// <param name="procedure">The procedure name.</param>
         /// <param name="args">A collection of positional arguments.</param>
+        /// <param name="procedureMode">The mode of the saved procedure. Defaults to <see cref="ProcedureMode.Write"/>.</param>
         /// <returns>A result set.</returns>
-        Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args);
+        Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, ProcedureMode procedureMode = ProcedureMode.Write);
 
         /// <summary>
         /// Call a saved procedure with parameters.
@@ -72,8 +74,9 @@ namespace NRedisStack
         /// <param name="procedure">The procedure name.</param>
         /// <param name="args">A collection of positional arguments.</param>
         /// <param name="kwargs">A collection of keyword arguments.</param>
+        /// <param name="procedureMode">The mode of the saved procedure. Defaults to <see cref="ProcedureMode.Write"/>.</param>
         /// <returns>A result set.</returns>
-        Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs);
+        Task<ResultSet> CallProcedureAsync(string graphName, string procedure, IEnumerable<string> args, Dictionary<string, List<string>> kwargs, ProcedureMode procedureMode = ProcedureMode.Write);
 
         /// <summary>
         /// Delete an existing graph.

--- a/src/NRedisStack/Graph/ProcedureMode.cs
+++ b/src/NRedisStack/Graph/ProcedureMode.cs
@@ -1,0 +1,11 @@
+namespace NRedisStack.Graph
+{
+    /// <summary>
+    /// Defines the mode of a saved procedure.
+    /// </summary>
+    public enum ProcedureMode
+    {
+        Read,
+        Write
+    }
+}

--- a/tests/NRedisStack.Tests/Graph/GraphTests.cs
+++ b/tests/NRedisStack.Tests/Graph/GraphTests.cs
@@ -966,7 +966,7 @@ public class GraphTests : AbstractNRedisStackTest, IDisposable
 
         var graph = db.GRAPH();
         // Create empty graph, otherwise call procedure will throw exception
-        graph.Query(graphName, "RETURN 1"); 
+        graph.Query(graphName, "RETURN 1");
 
         var labels0 = graph.CallProcedure(graphName, "db.labels");
         Assert.Empty(labels0);
@@ -1939,7 +1939,7 @@ public class GraphTests : AbstractNRedisStackTest, IDisposable
 
         var graph = db.GRAPH();
         // Create empty graph, otherwise call procedure will throw exception
-        await graph.QueryAsync(graphName, "RETURN 1"); 
+        await graph.QueryAsync(graphName, "RETURN 1");
 
         var labels0 = await graph.CallProcedureAsync(graphName, "db.labels");
         Assert.Empty(labels0);


### PR DESCRIPTION
# Problem

It is not possible to use `GraphCache` for replicas-only connections.
If `GraphCache.GetCachedData` is invoked, the following exception will be thrown

```
StackExchange.Redis.RedisServerException: READONLY You can't write against a read only replica.
   at NRedisStack.Auxiliary.ExecuteAsync(IDatabaseAsync db, SerializedCommand command)
   at NRedisStack.GraphCommandsAsync.QueryAsync(String graphName, String query, Nullable`1 timeout)
   at NRedisStack.GraphCommandsAsync.CallProcedureAsync(String graphName, String procedure, IEnumerable`1 args, Dictionary`2 kwargs)
   at NRedisStack.GraphCommandsAsync.CallProcedureAsync(String graphName, String procedure)
```

# Context

Current implementation uses `Query` and `QueryAsync` for every `CALL PROCEDURE`.
However, as procedures can be defined as `write` or `read` (as defined by `dbms.procedures()`), it would make sense to be able to select mode.

# Solution

Add option to specify procedures as Read or Write when calling `CallProcedure` and `CallProcedureAsync`.

## Discussion

I opted to go for the enum approach, and specify `ProcedureMode.Write` as default to avoid breaking existing use.
One could instead go with a new `CallReadProcedure` and `CallReadProcedureAsync`.
