### PR TITLE
Deprecate RedisGraph

### DIFF
--- a/src/NRedisStack/Graph/IGraphCommands.cs
+++ b/src/NRedisStack/Graph/IGraphCommands.cs
@@ -3,6 +3,7 @@ using StackExchange.Redis;
 
 namespace NRedisStack
 {
+    [Obsolete("RedisGraph is not supported since Redis 7.2 (https://redis.com/blog/redisgraph-eol/)")]
     public interface IGraphCommands
     {
         /// <summary>

--- a/src/NRedisStack/Graph/IGraphCommands.cs
+++ b/src/NRedisStack/Graph/IGraphCommands.cs
@@ -3,7 +3,7 @@ using StackExchange.Redis;
 
 namespace NRedisStack
 {
-    [Obsolete("RedisGraph is not supported since Redis 7.2 (https://redis.com/blog/redisgraph-eol/)")]
+    [Obsolete("RedisGraph supported is deprecated as of Redis Stack 7.2 (https://redis.com/blog/redisgraph-eol/)")]
     public interface IGraphCommands
     {
         /// <summary>

--- a/src/NRedisStack/Graph/IGraphCommandsAsync.cs
+++ b/src/NRedisStack/Graph/IGraphCommandsAsync.cs
@@ -3,7 +3,7 @@ using StackExchange.Redis;
 
 namespace NRedisStack
 {
-    [Obsolete("RedisGraph is not supported since Redis 7.2 (https://redis.com/blog/redisgraph-eol/)")]
+    [Obsolete("RedisGraph supported is deprecated as of Redis Stack 7.2 (https://redis.com/blog/redisgraph-eol/)")]
     public interface IGraphCommandsAsync
     {
         /// <summary>

--- a/src/NRedisStack/Graph/IGraphCommandsAsync.cs
+++ b/src/NRedisStack/Graph/IGraphCommandsAsync.cs
@@ -3,6 +3,7 @@ using StackExchange.Redis;
 
 namespace NRedisStack
 {
+    [Obsolete("RedisGraph is not supported since Redis 7.2 (https://redis.com/blog/redisgraph-eol/)")]
     public interface IGraphCommandsAsync
     {
         /// <summary>


### PR DESCRIPTION
Because of [RedisGraph's end-of-life announcement](https://redis.com/blog/redisgraph-eol/)
Closes #174