### PR TITLE
Fix library versioning: reading version from assembly

### DIFF
--- a/src/NRedisStack/Auxiliary.cs
+++ b/src/NRedisStack/Auxiliary.cs
@@ -131,7 +131,8 @@ namespace NRedisStack
 
         public static string GetNRedisStackVersion()
         {
-            return typeof(NRedisStack.Auxiliary).Assembly.GetName().Version.ToString();
+            Version version = typeof(Auxiliary).Assembly.GetName().Version!;
+            return $"{version.Major}.{version.Minor}.{version.Build}";
         }
     }
 }

--- a/src/NRedisStack/Auxiliary.cs
+++ b/src/NRedisStack/Auxiliary.cs
@@ -1,4 +1,3 @@
-using System.Xml.Linq;
 using NRedisStack.Core;
 using NRedisStack.RedisStackCommands;
 using StackExchange.Redis;
@@ -132,23 +131,7 @@ namespace NRedisStack
 
         public static string GetNRedisStackVersion()
         {
-            XDocument csprojDocument = GetCsprojDocument();
-
-            // Find the Version element and get its value.
-            var versionElement = csprojDocument.Root!
-                .Descendants("Version")
-                .FirstOrDefault();
-
-            return versionElement!.Value;
-        }
-
-        private static XDocument GetCsprojDocument()
-        {
-            string csprojFilePath = Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "..", "src", "NRedisStack", "NRedisStack.csproj");
-
-            // Load the .csproj file.
-            var csprojDocument = XDocument.Load(csprojFilePath);
-            return csprojDocument;
+            return typeof(NRedisStack.Auxiliary).Assembly.GetName().Version.ToString();
         }
     }
 }

--- a/src/NRedisStack/NRedisStack.csproj
+++ b/src/NRedisStack/NRedisStack.csproj
@@ -9,9 +9,9 @@
 	<Owners>Redis OSS</Owners>
 	<Description>.Net Client for Redis Stack</Description>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<Version>0.10.0</Version>
-	<ReleaseVersion>0.10.0</ReleaseVersion>
-	<PackageVersion>0.10.0</PackageVersion>
+	<Version>0.10.1</Version>
+	<ReleaseVersion>0.10.1</ReleaseVersion>
+	<PackageVersion>0.10.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes issue where NRedisStack was trying to read NRedisStack version out of the csproj file. What this means in practice is that any time anyone uses the nuget package for anything related to NRedisStack (any module commands), you would see an error e.g.:

```
Unhandled exception. System.IO.DirectoryNotFoundException: Could not find a part of the path '/src/NRedisStack/NRedisStack.csproj'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
```

The proper way to pull the version is by using the assembly. Produces a traditional Microsoft version number (e.g. 0.10.1.0) - Major.Minor.Build.Revision - that should be fine though.

