### PR TITLE
Bumped spellcheck action to latest version, since 0.23.0 is EOL

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check Spelling
-        uses: rojopolis/spellcheck-github-actions@0.23.0
+        uses: rojopolis/spellcheck-github-actions@0.35.0
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: Markdown


### PR DESCRIPTION
Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am _sunsetting_ version 0.23.0 as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to version 0.35.0, so this PR offers an update to the latest version.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, alternatively there are [Renovate](https://github.com/marketplace/renovate), if you want a PR proposing a basic configuration for Dependabot, please let me know.

jonasbn