### PR TITLE
Fix timestamp cast to datetime

### DIFF
--- a/src/NRedisStack/TimeSeries/DataTypes/TimeStamp.cs
+++ b/src/NRedisStack/TimeSeries/DataTypes/TimeStamp.cs
@@ -4,14 +4,14 @@
     /// A class represents timestamp.
     /// Value can be either primitive long, DateTime or one of the strings "-", "+", "*".
     /// </summary>
-    public class TimeStamp
+    public readonly record struct TimeStamp
     {
         private static readonly string[] constants = { "-", "+", "*" };
 
         /// <summary>
         /// TimeStamp value.
         /// </summary>
-        public object Value { get; private set; }
+        public object Value { get; }
 
         /// <summary>
         /// Build a TimeStamp from primitive long.
@@ -34,7 +34,7 @@
         {
             if (Array.IndexOf(constants, timestamp) == -1)
             {
-                throw new NotSupportedException(string.Format("The string {0} cannot be used", timestamp));
+                throw new NotSupportedException($"The string {timestamp} cannot be used");
             }
             Value = timestamp;
         }
@@ -77,14 +77,6 @@
         /// </summary>
         /// <param name="timeStamp">TimeStamp</param>
         public static implicit operator DateTime(TimeStamp timeStamp) => new DateTime(timeStamp);
-
-        /// <summary>
-        /// Equality of TimeSeriesTuple objects
-        /// </summary>
-        /// <param name="obj">Object to compare</param>
-        /// <returns>If two TimeStamp objects are equal</returns>
-        public override bool Equals(object? obj) =>
-            obj is TimeStamp stamp && EqualityComparer<object>.Default.Equals(Value, stamp.Value);
 
         /// <summary>
         /// TimeStamp object hash code.

--- a/src/NRedisStack/TimeSeries/DataTypes/TimeStamp.cs
+++ b/src/NRedisStack/TimeSeries/DataTypes/TimeStamp.cs
@@ -4,14 +4,14 @@
     /// A class represents timestamp.
     /// Value can be either primitive long, DateTime or one of the strings "-", "+", "*".
     /// </summary>
-    public readonly record struct TimeStamp
+    public class TimeStamp
     {
         private static readonly string[] constants = { "-", "+", "*" };
 
         /// <summary>
         /// TimeStamp value.
         /// </summary>
-        public object Value { get; }
+        public object Value { get; private set; }
 
         /// <summary>
         /// Build a TimeStamp from primitive long.
@@ -34,7 +34,7 @@
         {
             if (Array.IndexOf(constants, timestamp) == -1)
             {
-                throw new NotSupportedException($"The string {timestamp} cannot be used");
+                throw new NotSupportedException(string.Format("The string {0} cannot be used", timestamp));
             }
             Value = timestamp;
         }
@@ -77,6 +77,14 @@
         /// </summary>
         /// <param name="timeStamp">TimeStamp</param>
         public static implicit operator DateTime(TimeStamp timeStamp) => new DateTime(timeStamp);
+
+        /// <summary>
+        /// Equality of TimeSeriesTuple objects
+        /// </summary>
+        /// <param name="obj">Object to compare</param>
+        /// <returns>If two TimeStamp objects are equal</returns>
+        public override bool Equals(object? obj) =>
+            obj is TimeStamp stamp && EqualityComparer<object>.Default.Equals(Value, stamp.Value);
 
         /// <summary>
         /// TimeStamp object hash code.

--- a/src/NRedisStack/TimeSeries/DataTypes/TimeStamp.cs
+++ b/src/NRedisStack/TimeSeries/DataTypes/TimeStamp.cs
@@ -76,7 +76,7 @@
         /// Implicit cast from TimeStamp to DateTime.
         /// </summary>
         /// <param name="timeStamp">TimeStamp</param>
-        public static implicit operator DateTime(TimeStamp timeStamp) => new DateTime(timeStamp);
+        public static implicit operator DateTime(TimeStamp timeStamp) => DateTimeOffset.FromUnixTimeMilliseconds(timeStamp).DateTime;
 
         /// <summary>
         /// Equality of TimeSeriesTuple objects

--- a/src/NRedisStack/TimeSeries/TimeSeriesAux.cs
+++ b/src/NRedisStack/TimeSeries/TimeSeriesAux.cs
@@ -200,11 +200,8 @@ namespace NRedisStack
 
         public static void AddTimeStamp(this IList<object> args, TimeStamp timeStamp)
         {
-            if (timeStamp != null)
-            {
-                args.Add(TimeSeriesArgs.TIMESTAMP);
-                args.Add(timeStamp.Value);
-            }
+            args.Add(TimeSeriesArgs.TIMESTAMP);
+            args.Add(timeStamp.Value);
         }
 
         public static void AddRule(this IList<object> args, TimeSeriesRule rule)
@@ -250,11 +247,11 @@ namespace NRedisStack
             return args;
         }
 
-        public static List<object> BuildTsIncrDecrByArgs(string key, double value, TimeStamp? timestamp, long? retentionTime,
+        public static List<object> BuildTsIncrDecrByArgs(string key, double value, TimeStamp? timestampMaybe, long? retentionTime,
             IReadOnlyCollection<TimeSeriesLabel>? labels, bool? uncompressed, long? chunkSizeBytes)
         {
             var args = new List<object> { key, value };
-            if (timestamp != null) args.AddTimeStamp(timestamp);
+            if (timestampMaybe is {} timestamp) args.AddTimeStamp(timestamp);
             args.AddRetentionTime(retentionTime);
             args.AddChunkSize(chunkSizeBytes);
             if (labels != null) args.AddLabels(labels);

--- a/src/NRedisStack/TimeSeries/TimeSeriesAux.cs
+++ b/src/NRedisStack/TimeSeries/TimeSeriesAux.cs
@@ -79,9 +79,9 @@ namespace NRedisStack
             }
         }
 
-        public static void AddAlign(this IList<object> args, TimeStamp? alignMaybe)
+        public static void AddAlign(this IList<object> args, TimeStamp? align)
         {
-            if (alignMaybe is {} align)
+            if (align != null)
             {
                 args.Add(TimeSeriesArgs.ALIGN);
                 args.Add(align.Value);
@@ -200,8 +200,11 @@ namespace NRedisStack
 
         public static void AddTimeStamp(this IList<object> args, TimeStamp timeStamp)
         {
-            args.Add(TimeSeriesArgs.TIMESTAMP);
-            args.Add(timeStamp.Value);
+            if (timeStamp != null)
+            {
+                args.Add(TimeSeriesArgs.TIMESTAMP);
+                args.Add(timeStamp.Value);
+            }
         }
 
         public static void AddRule(this IList<object> args, TimeSeriesRule rule)
@@ -247,11 +250,11 @@ namespace NRedisStack
             return args;
         }
 
-        public static List<object> BuildTsIncrDecrByArgs(string key, double value, TimeStamp? timestampMaybe, long? retentionTime,
+        public static List<object> BuildTsIncrDecrByArgs(string key, double value, TimeStamp? timestamp, long? retentionTime,
             IReadOnlyCollection<TimeSeriesLabel>? labels, bool? uncompressed, long? chunkSizeBytes)
         {
             var args = new List<object> { key, value };
-            if (timestampMaybe is {} timestamp) args.AddTimeStamp(timestamp);
+            if (timestamp != null) args.AddTimeStamp(timestamp);
             args.AddRetentionTime(retentionTime);
             args.AddChunkSize(chunkSizeBytes);
             if (labels != null) args.AddLabels(labels);


### PR DESCRIPTION
The current implicit cast operator from TimeStamp to DateTime uses the DateTime's constructor that accepts [`ticks`](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.-ctor?view=net-8.0#system-datetime-ctor(system-int64)) as long, but the value of TimeStamp is actuallly milliseconds passed since 01/01/1970.