### PR TITLE
Always submitting codecov

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -125,3 +125,9 @@ jobs:
         run: |
           START wsl ./redis-stack-server-${{env.redis_stack_version}}/bin/redis-stack-server &
           dotnet test -f net481 --no-build --verbosity normal
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          verbose: true
+


### PR DESCRIPTION
Based on research, it turns out that codecov is already, and will generally merge coverage reports. That being the case, let's merge them all, always.