### PR TITLE
Switch to public Redis Enterprise for CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        enterprise_version: ['7.2.4-92']
+        enterprise_version: ['7.4.2-54']
         env_file_mode: ['enterprise', 'enterprise_oss_cluster']
 
     steps:
@@ -41,20 +41,17 @@ jobs:
           repository: redislabs/redis-ee-docker
           path: redis-ee-docker
 
-
       - name: Start docker
         working-directory: redis-ee-docker
         env:
-          IMAGE: redislabs/redis-internal:${{ matrix.enterprise_version }}
-          DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          IMAGE: redislabs/redis:${{ matrix.enterprise_version }}
         run: ./build.sh
 
       - name: .NET Core 8
         uses: actions/setup-dotnet@v2
-
         with:
           dotnet-version: '8.0.x'
+
       - name: Restore dependencies
         run: dotnet restore
 


### PR DESCRIPTION
Don't use private Docker images, to avoid the need of Docker credentials as secrets. Such secrets bring complications when receiving PRs from forked repositories.