### PR TITLE
set initial client info with first 'transaction' creation

### DIFF
--- a/src/NRedisStack/Transactions.cs
+++ b/src/NRedisStack/Transactions.cs
@@ -9,6 +9,7 @@ namespace NRedisStack
 
         public Transaction(IDatabase db)
         {
+            db.SetInfoInPipeline();
             _transaction = db.CreateTransaction();
         }
 


### PR DESCRIPTION
fixes the issue #289 
turns out a new Transaction on a brand new connection attempt to set client info with a ([pipeline](https://github.com/redis/NRedisStack/blob/26ff43859d1eb7e64d1c9a9a40897a6ea2c2cd20/src/NRedisStack/Auxiliary.cs#L68)) with causes trouble.

attempting to fix it while creating transaction by calling setinfo via Auxiliary.

