### PR TITLE
Verify library support for float16 and bfloat15 types in vector fields

### DIFF
--- a/tests/NRedisStack.Tests/Search/IndexCreationTests.cs
+++ b/tests/NRedisStack.Tests/Search/IndexCreationTests.cs
@@ -2,7 +2,6 @@ using StackExchange.Redis;
 using NRedisStack.Search;
 using NRedisStack.RedisStackCommands;
 using Xunit;
-using System.Runtime.InteropServices;
 using NetTopologySuite.Geometries;
 
 namespace NRedisStack.Tests.Search;
@@ -144,10 +143,12 @@ public class IndexCreationTests : AbstractNRedisStackTest, IDisposable
         Assert.True(ft.Create("idx", new FTCreateParams(), schema));
 
         short[] vec1 = new short[] { 2, 1, 2, 2, 2 };
-        byte[] vec1ToBytes = MemoryMarshal.Cast<short, byte>(vec1).ToArray();
+        byte[] vec1ToBytes = new byte[vec1.Length * sizeof(short)];
+        Buffer.BlockCopy(vec1, 0, vec1ToBytes, 0, vec1ToBytes.Length);
 
         short[] vec2 = new short[] { 1, 2, 2, 2 };
-        byte[] vec2ToBytes = MemoryMarshal.Cast<short, byte>(vec2).ToArray();
+        byte[] vec2ToBytes = new byte[vec2.Length * sizeof(short)];
+        Buffer.BlockCopy(vec2, 0, vec2ToBytes, 0, vec2ToBytes.Length);
 
         var entries = new HashEntry[] { new HashEntry("v", vec1ToBytes), new HashEntry("v2", vec2ToBytes) };
         db.HashSet("a", entries);

--- a/tests/NRedisStack.Tests/Search/IndexCreationTests.cs
+++ b/tests/NRedisStack.Tests/Search/IndexCreationTests.cs
@@ -1,0 +1,52 @@
+using StackExchange.Redis;
+using NRedisStack.Search;
+using NRedisStack.RedisStackCommands;
+using Xunit;
+using System.Runtime.InteropServices;
+
+namespace NRedisStack.Tests.Search;
+
+public class IndexCreationTests : AbstractNRedisStackTest, IDisposable
+{
+    public IndexCreationTests(RedisFixture redisFixture) : base(redisFixture) { }
+
+    [SkipIfRedis(Is.OSSCluster, Comparison.LessThan, "7.3.240")]
+    public void TestCreateFloat16VectorField()
+    {
+        IDatabase db = redisFixture.Redis.GetDatabase();
+        db.Execute("FLUSHALL");
+        var ft = db.FT(2);
+
+        var schema = new Schema().AddVectorField("v", Schema.VectorField.VectorAlgo.FLAT, new Dictionary<string, object>()
+        {
+            ["TYPE"] = "FLOAT16",
+            ["DIM"] = "5",
+            ["DISTANCE_METRIC"] = "L2",
+        }).AddVectorField("v2", Schema.VectorField.VectorAlgo.FLAT, new Dictionary<string, object>()
+        {
+            ["TYPE"] = "BFLOAT16",
+            ["DIM"] = "4",
+            ["DISTANCE_METRIC"] = "L2",
+        });
+        Assert.True(ft.Create("idx", new FTCreateParams(), schema));
+
+        short[] vec1 = new short[] { 2, 1, 2, 2, 2 };
+        byte[] vec1ToBytes = MemoryMarshal.Cast<short, byte>(vec1).ToArray();
+
+        short[] vec2 = new short[] { 1, 2, 2, 2 };
+        byte[] vec2ToBytes = MemoryMarshal.Cast<short, byte>(vec2).ToArray();
+
+        var entries = new HashEntry[] { new HashEntry("v", vec1ToBytes), new HashEntry("v2", vec2ToBytes) };
+        db.HashSet("a", entries);
+        db.HashSet("b", entries);
+        db.HashSet("c", entries);
+
+        var q = new Query("*=>[KNN 2 @v $vec]").ReturnFields("__v_score");
+        var res = ft.Search("idx", q.AddParam("vec", vec1ToBytes));
+        Assert.Equal(2, res.TotalResults);
+
+        q = new Query("*=>[KNN 2 @v2 $vec]").ReturnFields("__v_score");
+        res = ft.Search("idx", q.AddParam("vec", vec2ToBytes));
+        Assert.Equal(2, res.TotalResults);
+    }
+}

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -2619,7 +2619,7 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
         Assert.Equal(2L, await ft.SugLenAsync(key));
     }
 
-    [SkipIfRedis(Is.Enterprise)]
+    [SkipIfRedis(Is.Enterprise, Comparison.GreaterThanOrEqual, "7.3.240")]
     public void TestProfileSearch()
     {
         IDatabase db = redisFixture.Redis.GetDatabase();
@@ -2643,7 +2643,7 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
         Assert.Equal("1", iteratorsProfile["Size"].ToString());
     }
 
-    [SkipIfRedis(Is.Enterprise)]
+    [SkipIfRedis(Is.Enterprise, Comparison.GreaterThanOrEqual, "7.3.240")]
     public async Task TestProfileSearchAsync()
     {
         IDatabase db = redisFixture.Redis.GetDatabase();
@@ -2727,7 +2727,7 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
         Assert.Equal(2, aggregateRes.TotalResults);
     }
 
-    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.3.240")]
+    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.3.242")]
     public void TestProfileIssue306()
     {
         IDatabase db = redisFixture.Redis.GetDatabase();
@@ -2757,7 +2757,7 @@ public class SearchTests : AbstractNRedisStackTest, IDisposable
         Assert.Equal(2, aggregateRes.TotalResults);
     }
 
-    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.3.240")]
+    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.3.242")]
     public async Task TestProfileAsyncIssue306()
     {
         IDatabase db = redisFixture.Redis.GetDatabase();


### PR DESCRIPTION
Closes/Fixes #316 

library already supports vector field attributes as string,
just added an integration test