### PR TITLE
switch to docker compose

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -41,7 +41,7 @@ jobs:
 
           - name: Run redis-stack-server docker
             working-directory: .github
-            run: docker-compose up -d redis-stack-${{inputs.redis_stack_type}}
+            run: docker compose up -d redis-stack-${{inputs.redis_stack_type}}
 
           - name: Set .env variables
             uses: xom9ikk/dotenv@v2


### PR DESCRIPTION
docker-compose is not available by default anymore on `ubuntu-latest`
[details here ](https://github.com/actions/runner-images/issues/9692)
