### PR TITLE
Set DIALECT 2 as default configurable dialect version

### DIFF
--- a/src/NRedisStack/ModulePrefixes.cs
+++ b/src/NRedisStack/ModulePrefixes.cs
@@ -17,7 +17,7 @@ namespace NRedisStack.RedisStackCommands
 
         public static TdigestCommands TDIGEST(this IDatabase db) => new TdigestCommands(db);
 
-        public static SearchCommands FT(this IDatabase db, int? searchDialect = null) => new SearchCommands(db, searchDialect);
+        public static SearchCommands FT(this IDatabase db, int? searchDialect = 2) => new SearchCommands(db, searchDialect);
 
         public static JsonCommands JSON(this IDatabase db) => new JsonCommands(db);
 

--- a/src/NRedisStack/Search/AggregationRequest.cs
+++ b/src/NRedisStack/Search/AggregationRequest.cs
@@ -2,7 +2,7 @@
 using NRedisStack.Search.Literals;
 
 namespace NRedisStack.Search;
-public class AggregationRequest
+public class AggregationRequest : IDialectAwareParam
 {
     private List<object> args = new List<object>(); // Check if Readonly
     private bool isWithCursor = false;
@@ -183,5 +183,11 @@ public class AggregationRequest
     public bool IsWithCursor()
     {
         return isWithCursor;
+    }
+
+    int? IDialectAwareParam.Dialect
+    {
+        get { return dialect; }
+        set { dialect = value; }
     }
 }

--- a/src/NRedisStack/Search/FTSpellCheckParams.cs
+++ b/src/NRedisStack/Search/FTSpellCheckParams.cs
@@ -1,7 +1,7 @@
 using NRedisStack.Search.Literals;
 namespace NRedisStack.Search
 {
-    public class FTSpellCheckParams
+    public class FTSpellCheckParams : IDialectAwareParam
     {
         List<object> args = new List<object>();
         private List<KeyValuePair<string, string>> terms = new List<KeyValuePair<string, string>>();
@@ -60,37 +60,28 @@ namespace NRedisStack.Search
 
         public void SerializeRedisArgs()
         {
-            Distance();
-            Terms();
-            Dialect();
-        }
-
-        private void Dialect()
-        {
             if (dialect != null)
             {
                 args.Add(SearchArgs.DIALECT);
                 args.Add(dialect);
             }
-        }
-
-        private void Terms()
-        {
             foreach (var term in terms)
             {
                 args.Add(SearchArgs.TERMS);
                 args.Add(term.Value);
                 args.Add(term.Key);
             }
-        }
-
-        private void Distance()
-        {
             if (distance != null)
             {
                 args.Add(SearchArgs.DISTANCE);
                 args.Add(distance);
             }
+        }
+
+        int? IDialectAwareParam.Dialect
+        {
+            get { return dialect; }
+            set { dialect = value; }
         }
     }
 }

--- a/src/NRedisStack/Search/IDialectAwareParam.cs
+++ b/src/NRedisStack/Search/IDialectAwareParam.cs
@@ -1,0 +1,15 @@
+namespace NRedisStack.Search
+{
+    /// <summary>
+    /// Interface for dialect-aware parameters.
+    /// To provide a single interface to manage default dialect version under which to execute the query.
+    /// </summary>
+    internal interface IDialectAwareParam
+    {
+        /// <summary>
+        ///  Selects the dialect version under which to execute the query.
+        /// </summary>
+        internal int? Dialect { get; set; }
+    }
+
+}

--- a/src/NRedisStack/Search/Query.cs
+++ b/src/NRedisStack/Search/Query.cs
@@ -7,7 +7,7 @@ namespace NRedisStack.Search
     /// <summary>
     ///  Query represents query parameters and filters to load results from the engine
     /// </summary>
-    public sealed class Query
+    public sealed class Query : IDialectAwareParam
     {
         /// <summary>
         /// Filter represents a filtering rules in a query
@@ -691,5 +691,12 @@ namespace NRedisStack.Search
             _expander = field;
             return this;
         }
+
+        int? IDialectAwareParam.Dialect
+        {
+            get { return dialect; }
+            set { dialect = value; }
+        }
+
     }
 }


### PR DESCRIPTION
This change basically sets DIALECT 2 as the default dialect version on client side. Where DIALECT is relevant, each search/query  will be using this default value unless it is configured otherwise. 

Configuration could be changed explicitly at `IDatabase` level or at `Query`/`AggregationRequest` level.
A sample code showing how to change it using different constructs.

```java
        // setting DIALECT at database level
        IDatabase db = ConnectionMultiplexer.Connect("localhost:6379").GetDatabase();
        SearchCommands ft = db.FT();
        ft.SetDefaultDialect(4);
        SearchResult result = ft.Search(index, new Query("@version:[123]"));

        // setting DIALECt at query level
        IDatabase db = ConnectionMultiplexer.Connect("localhost:6379").GetDatabase();
        ISearchCommands ft = db.FT();
        SearchResult result = ft.Search(index, new Query("@version:[123]").Dialect(4));
```