### PR TITLE
Piipeline fix for dotnet versions in ubuntu-latest

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -37,7 +37,10 @@ jobs:
           - name: .NET Core 8
             uses: actions/setup-dotnet@v3
             with:
-              dotnet-version: 8
+              dotnet-version: |
+                6
+                7
+                8
 
           - name: Run redis-stack-server docker
             working-directory: .github


### PR DESCRIPTION
looks like GH is rolling out Ubuntu 24.04 as ubuntu-latest.
older versions of dotnet is not bundled in current image.
this fixes failing pipeline due to lack of older versions of dotnet.