### PR TITLE
Fix default dialect settings 

### DIFF
--- a/src/NRedisStack/Search/SearchCommands.cs
+++ b/src/NRedisStack/Search/SearchCommands.cs
@@ -133,6 +133,7 @@ namespace NRedisStack
         /// <inheritdoc/>
         public Tuple<SearchResult, Dictionary<string, RedisResult>> ProfileSearch(string indexName, Query q, bool limited = false)
         {
+            setDefaultDialectIfUnset(q);
             return _db.Execute(SearchCommandBuilder.ProfileSearch(indexName, q, limited))
                             .ToProfileSearchResult(q);
         }

--- a/src/NRedisStack/Search/SearchCommandsAsync.cs
+++ b/src/NRedisStack/Search/SearchCommandsAsync.cs
@@ -164,12 +164,14 @@ namespace NRedisStack
         /// <inheritdoc/>
         public async Task<Tuple<SearchResult, Dictionary<string, RedisResult>>> ProfileSearchAsync(string indexName, Query q, bool limited = false)
         {
+            setDefaultDialectIfUnset(q);
             return (await _db.ExecuteAsync(SearchCommandBuilder.ProfileSearch(indexName, q, limited)))
                             .ToProfileSearchResult(q);
         }
         /// <inheritdoc/>
         public async Task<Tuple<AggregationResult, Dictionary<string, RedisResult>>> ProfileAggregateAsync(string indexName, AggregationRequest query, bool limited = false)
         {
+            setDefaultDialectIfUnset(query);
             return (await _db.ExecuteAsync(SearchCommandBuilder.ProfileAggregate(indexName, query, limited)))
                             .ToProfileAggregateResult(query);
         }


### PR DESCRIPTION
Fix default dialect settings for `ProfileSearch` and `ProfileAggregateAsync`