### PR TITLE
Fix nested batch issue when initial command is within a pipeline

### DIFF
--- a/src/NRedisStack/Pipeline.cs
+++ b/src/NRedisStack/Pipeline.cs
@@ -6,6 +6,7 @@ public class Pipeline
 {
     public Pipeline(IDatabase db)
     {
+        db.SetInfoInPipeline();
         _batch = db.CreateBatch();
     }
 

--- a/tests/NRedisStack.Tests/PipelineTests.cs
+++ b/tests/NRedisStack.Tests/PipelineTests.cs
@@ -156,4 +156,22 @@ public class PipelineTests : AbstractNRedisStackTest, IDisposable
         Assert.True(setResponse.Result);
         Assert.Equal("{\"Name\":\"Shachar\",\"Age\":23}", getResponse.Result.ToString());
     }
+
+    [SkippableTheory]
+    [MemberData(nameof(EndpointsFixture.Env.StandaloneOnly), MemberType = typeof(EndpointsFixture.Env))]
+    [Obsolete]
+    public async void Issue401_TestPipelineAsInitialCommand(string endpointId)
+    {
+        IDatabase db = GetCleanDatabase(endpointId);
+
+        Auxiliary.ResetInfoDefaults(); // demonstrate first connection
+        var pipeline = new Pipeline(db);
+
+        var setTask = pipeline.Json.SetAsync("json-key", "$", "{}");
+        _ = pipeline.Db.KeyExpireAsync(key, TimeSpan.FromSeconds(10));
+
+        pipeline.Execute();
+
+        Assert.True(await setTask);
+    }
 }


### PR DESCRIPTION
Closes/Fixes #401 

This pr resolves the issue caused by attempting to set lib info with a pipeline while the initial command itself is a pipeline in customer app.