### PR TITLE
Backport of: Fix failing docuement.load in query results with an expired doc #357 

### DIFF
--- a/src/NRedisStack/Search/Document.cs
+++ b/src/NRedisStack/Search/Document.cs
@@ -31,6 +31,10 @@ public class Document
     {
         Document ret = new Document(id, score, payload);
         if (fields == null) return ret;
+        if (fields.Length == 1 && fields[0].IsNull)
+        {
+            return ret;
+        }
         for (int i = 0; i < fields.Length; i += 2)
         {
             string fieldName = fields[i]!;


### PR DESCRIPTION
* fix failing docuement load in query results with an expired doc

* IsCompletedSuccessfully" is *not* available in all test envs

* set test case for non cluster env