### PR TITLE
 Bump Redis 8.0 version(8.0-RC2-pre) in pipeline

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ jobs:
         max-parallel: 15
         fail-fast: false
         matrix:
-          redis-version: [ '8.0-RC1-pre', '${{ needs.redis_version.outputs.CURRENT }}', '7.2.6', '6.2.16']
+          redis-version: [ '8.0-RC2-pre', '${{ needs.redis_version.outputs.CURRENT }}', '7.2.6', '6.2.16']
           dotnet-version: ['6.0', '7.0', '8.0']
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true

--- a/tests/NRedisStack.Tests/TimeSeries/TestDataTypes/TestTimeSeriesInformation.cs
+++ b/tests/NRedisStack.Tests/TimeSeries/TestDataTypes/TestTimeSeriesInformation.cs
@@ -14,9 +14,61 @@ namespace NRedisTimeSeries.Test.TestDataTypes
         {
         }
 
-        [Fact]
-        [Obsolete]
+        [SkipIfRedis(Comparison.GreaterThanOrEqual, "7.9.240")]
+        [InlineData]
         public void TestInformationSync()
+        {
+            string key = CreateKeyName();
+            IDatabase db = GetCleanDatabase();
+            var ts = db.TS();
+            ts.Add(key, "*", 1.1);
+            ts.Add(key, "*", 1.3, duplicatePolicy: TsDuplicatePolicy.LAST);
+
+            TimeSeriesInformation info = ts.Info(key);
+            TimeSeriesInformation infoDebug = ts.Info(key, debug: true);
+
+            Assert.Equal(0, info.RetentionTime);
+            Assert.Equal(1, info.ChunkCount);
+            Assert.Null(info.DuplicatePolicy);
+            Assert.Null(info.KeySelfName);
+            Assert.Null(info.Chunks);
+
+            Assert.Equal(0, infoDebug.RetentionTime);
+            Assert.Equal(1, infoDebug.ChunkCount);
+            Assert.Null(infoDebug.DuplicatePolicy);
+            Assert.Equal(infoDebug.KeySelfName, key);
+            Assert.Single(infoDebug.Chunks!);
+        }
+
+        [SkipIfRedis(Comparison.GreaterThanOrEqual, "7.9.240")]
+        [InlineData]
+        public async Task TestInformationAsync()
+        {
+            string key = CreateKeyName();
+            IDatabase db = GetCleanDatabase();
+            var ts = db.TS();
+            await ts.AddAsync(key, "*", 1.1);
+            await ts.AddAsync(key, "*", 1.3, duplicatePolicy: TsDuplicatePolicy.LAST);
+
+            TimeSeriesInformation info = await ts.InfoAsync(key);
+            TimeSeriesInformation infoDebug = await ts.InfoAsync(key, debug: true);
+
+            Assert.Equal(0, info.RetentionTime);
+            Assert.Equal(1, info.ChunkCount);
+            Assert.Null(info.DuplicatePolicy);
+            Assert.Null(info.KeySelfName);
+            Assert.Null(info.Chunks);
+
+            Assert.Equal(0, infoDebug.RetentionTime);
+            Assert.Equal(1, infoDebug.ChunkCount);
+            Assert.Null(infoDebug.DuplicatePolicy);
+            Assert.Equal(infoDebug.KeySelfName, key);
+            Assert.Single(infoDebug.Chunks!);
+        }
+
+        [SkipIfRedis(Comparison.LessThan, "7.9.240")]
+        [InlineData]
+        public void TestInformationSync_CE80()
         {
             string key = CreateKeyName();
             IDatabase db = GetCleanDatabase();
@@ -40,9 +92,9 @@ namespace NRedisTimeSeries.Test.TestDataTypes
             Assert.Single(infoDebug.Chunks!);
         }
 
-        [Fact]
-        [Obsolete]
-        public async Task TestInformationAsync()
+        [SkipIfRedis(Comparison.LessThan, "7.9.240")]
+        [InlineData]
+        public async Task TestInformationAsync_CE80()
         {
             string key = CreateKeyName();
             IDatabase db = GetCleanDatabase();

--- a/tests/NRedisStack.Tests/TimeSeries/TestDataTypes/TestTimeSeriesInformation.cs
+++ b/tests/NRedisStack.Tests/TimeSeries/TestDataTypes/TestTimeSeriesInformation.cs
@@ -29,13 +29,13 @@ namespace NRedisTimeSeries.Test.TestDataTypes
 
             Assert.Equal(0, info.RetentionTime);
             Assert.Equal(1, info.ChunkCount);
-            Assert.Null(info.DuplicatePolicy);
+            Assert.Equal(TsDuplicatePolicy.BLOCK, info.DuplicatePolicy);
             Assert.Null(info.KeySelfName);
             Assert.Null(info.Chunks);
 
             Assert.Equal(0, infoDebug.RetentionTime);
             Assert.Equal(1, infoDebug.ChunkCount);
-            Assert.Null(infoDebug.DuplicatePolicy);
+            Assert.Equal(TsDuplicatePolicy.BLOCK, infoDebug.DuplicatePolicy);
             Assert.Equal(infoDebug.KeySelfName, key);
             Assert.Single(infoDebug.Chunks!);
         }
@@ -55,13 +55,13 @@ namespace NRedisTimeSeries.Test.TestDataTypes
 
             Assert.Equal(0, info.RetentionTime);
             Assert.Equal(1, info.ChunkCount);
-            Assert.Null(info.DuplicatePolicy);
+            Assert.Equal(TsDuplicatePolicy.BLOCK, info.DuplicatePolicy);
             Assert.Null(info.KeySelfName);
             Assert.Null(info.Chunks);
 
             Assert.Equal(0, infoDebug.RetentionTime);
             Assert.Equal(1, infoDebug.ChunkCount);
-            Assert.Null(infoDebug.DuplicatePolicy);
+            Assert.Equal(TsDuplicatePolicy.BLOCK, infoDebug.DuplicatePolicy);
             Assert.Equal(infoDebug.KeySelfName, key);
             Assert.Single(infoDebug.Chunks!);
         }


### PR DESCRIPTION
This PR is to update Redis CE 8.0 version as `8.0-RC2-pre`.