### PR TITLE
 Bump Redis 8.0.1 version(8.0.1-pre) in pipeline

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ jobs:
         max-parallel: 15
         fail-fast: false
         matrix:
-          redis-version: [ '8.0-RC2-pre', '${{ needs.redis_version.outputs.CURRENT }}', '7.2.6', '6.2.16']
+          redis-version: [ '8.0.1-pre', '${{ needs.redis_version.outputs.CURRENT }}', '7.2.6', '6.2.16']
           dotnet-version: ['6.0', '7.0', '8.0']
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true


### PR DESCRIPTION
This PR is to update Redis CE 8.0 version as `8.0.1-pre`.
