### PR TITLE
Setting client lib name properly by wrapping multiplxer creation 

### DIFF
--- a/src/NRedisStack/Auxiliary.cs
+++ b/src/NRedisStack/Auxiliary.cs
@@ -6,12 +6,12 @@ namespace NRedisStack;
 
 public static class Auxiliary
 {
-    private static string? _libraryName = $"NRedisStack(.NET_v{Environment.Version})";
+    private static string? _libraryName = $"NRedisStack-{GetNRedisStackVersion()}";
     private static bool _setInfo = true;
     public static void ResetInfoDefaults()
     {
         _setInfo = true;
-        _libraryName = $"NRedisStack(.NET_v{Environment.Version})";
+        _libraryName = $"NRedisStack-{GetNRedisStackVersion()}";
     }
     public static List<object> MergeArgs(RedisKey key, params RedisValue[] items)
     {
@@ -126,4 +126,7 @@ public static class Auxiliary
         Version version = typeof(Auxiliary).Assembly.GetName().Version!;
         return $"{version.Major}.{version.Minor}.{version.Build}";
     }
+
+    internal static string GetNRedisStackLibName() => _libraryName!;
+
 }

--- a/src/NRedisStack/CoreCommands/CoreCommands.cs
+++ b/src/NRedisStack/CoreCommands/CoreCommands.cs
@@ -4,11 +4,15 @@ using StackExchange.Redis;
 
 namespace NRedisStack;
 
+/// <summary>
+/// Class that provides access to some of blocking Redis core commands
+/// </summary>
 public static class CoreCommands
 {
     /// <summary>
     /// Sets information specific to the client or connection.
     /// </summary>
+    /// <param name="db">The <see cref="IDatabase"/> class where this extension method is applied.</param>
     /// <param name="attr">which attribute to set</param>
     /// <param name="value">the attribute value</param>
     /// <returns><see langword="true"/> if the attribute name was successfully set, Error otherwise.</returns>

--- a/src/NRedisStack/DatabaseWrapper.cs
+++ b/src/NRedisStack/DatabaseWrapper.cs
@@ -1,0 +1,2410 @@
+using StackExchange.Redis;
+using System;
+using System.Net;
+
+namespace NRedisStack.RedisStackCommands
+{
+    internal class DatabaseWrapper : IDatabase
+    {
+        protected readonly IDatabase _db;
+
+        public DatabaseWrapper(IDatabase db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+
+        public int Database => _db.Database;
+
+        public IConnectionMultiplexer Multiplexer => _db.Multiplexer;
+
+        public IBatch CreateBatch(object? asyncState = null)
+        {
+            return _db.CreateBatch(asyncState);
+        }
+
+        public ITransaction CreateTransaction(object? asyncState = null)
+        {
+            return _db.CreateTransaction(asyncState);
+        }
+
+        public RedisValue DebugObject(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.DebugObject(key, flags);
+        }
+
+        public Task<RedisValue> DebugObjectAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.DebugObjectAsync(key, flags);
+        }
+
+        public RedisResult Execute(string command, params object[] args)
+        {
+            return _db.Execute(command, args);
+        }
+
+        public RedisResult Execute(string command, ICollection<object> args, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.Execute(command, args, flags);
+        }
+
+        public Task<RedisResult> ExecuteAsync(string command, params object[] args)
+        {
+            return _db.ExecuteAsync(command, args);
+        }
+
+        public Task<RedisResult> ExecuteAsync(string command, ICollection<object>? args, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ExecuteAsync(command, args, flags);
+        }
+
+        public bool GeoAdd(RedisKey key, double longitude, double latitude, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoAdd(key, longitude, latitude, member, flags);
+        }
+
+        public bool GeoAdd(RedisKey key, GeoEntry value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoAdd(key, value, flags);
+        }
+
+        public long GeoAdd(RedisKey key, GeoEntry[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoAdd(key, values, flags);
+        }
+
+        public Task<bool> GeoAddAsync(RedisKey key, double longitude, double latitude, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoAddAsync(key, longitude, latitude, member, flags);
+        }
+
+        public Task<bool> GeoAddAsync(RedisKey key, GeoEntry value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoAddAsync(key, value, flags);
+        }
+
+        public Task<long> GeoAddAsync(RedisKey key, GeoEntry[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoAddAsync(key, values, flags);
+        }
+
+        public double? GeoDistance(RedisKey key, RedisValue member1, RedisValue member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoDistance(key, member1, member2, unit, flags);
+        }
+
+        public Task<double?> GeoDistanceAsync(RedisKey key, RedisValue member1, RedisValue member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoDistanceAsync(key, member1, member2, unit, flags);
+        }
+
+        public string?[] GeoHash(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoHash(key, members, flags);
+        }
+
+        public string? GeoHash(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoHash(key, member, flags);
+        }
+
+        public Task<string?[]> GeoHashAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoHashAsync(key, members, flags);
+        }
+
+        public Task<string?> GeoHashAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoHashAsync(key, member, flags);
+        }
+
+        public GeoPosition?[] GeoPosition(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoPosition(key, members, flags);
+        }
+
+        public GeoPosition? GeoPosition(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoPosition(key, member, flags);
+        }
+
+        public Task<GeoPosition?[]> GeoPositionAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoPositionAsync(key, members, flags);
+        }
+
+        public Task<GeoPosition?> GeoPositionAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoPositionAsync(key, member, flags);
+        }
+
+        public GeoRadiusResult[] GeoRadius(RedisKey key, RedisValue member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoRadius(key, member, radius, unit, count, order, options, flags);
+        }
+
+        public GeoRadiusResult[] GeoRadius(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoRadius(key, longitude, latitude, radius, unit, count, order, options, flags);
+        }
+
+        public Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, RedisValue member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoRadiusAsync(key, member, radius, unit, count, order, options, flags);
+        }
+
+        public Task<GeoRadiusResult[]> GeoRadiusAsync(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoRadiusAsync(key, longitude, latitude, radius, unit, count, order, options, flags);
+        }
+
+        public bool GeoRemove(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoRemove(key, member, flags);
+        }
+
+        public Task<bool> GeoRemoveAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoRemoveAsync(key, member, flags);
+        }
+
+        public GeoRadiusResult[] GeoSearch(RedisKey key, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoSearch(key, member, shape, count, demandClosest, order, options, flags);
+        }
+
+        public GeoRadiusResult[] GeoSearch(RedisKey key, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoSearch(key, longitude, latitude, shape, count, demandClosest, order, options, flags);
+        }
+
+        public long GeoSearchAndStore(RedisKey sourceKey, RedisKey destinationKey, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoSearchAndStore(sourceKey, destinationKey, member, shape, count, demandClosest, order, storeDistances, flags);
+        }
+
+        public long GeoSearchAndStore(RedisKey sourceKey, RedisKey destinationKey, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoSearchAndStore(sourceKey, destinationKey, longitude, latitude, shape, count, demandClosest, order, storeDistances, flags);
+        }
+
+        public Task<long> GeoSearchAndStoreAsync(RedisKey sourceKey, RedisKey destinationKey, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoSearchAndStoreAsync(sourceKey, destinationKey, member, shape, count, demandClosest, order, storeDistances, flags);
+        }
+
+        public Task<long> GeoSearchAndStoreAsync(RedisKey sourceKey, RedisKey destinationKey, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, bool storeDistances = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoSearchAndStoreAsync(sourceKey, destinationKey, longitude, latitude, shape, count, demandClosest, order, storeDistances, flags);
+        }
+
+        public Task<GeoRadiusResult[]> GeoSearchAsync(RedisKey key, RedisValue member, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoSearchAsync(key, member, shape, count, demandClosest, order, options, flags);
+        }
+
+        public Task<GeoRadiusResult[]> GeoSearchAsync(RedisKey key, double longitude, double latitude, GeoSearchShape shape, int count = -1, bool demandClosest = true, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.GeoSearchAsync(key, longitude, latitude, shape, count, demandClosest, order, options, flags);
+        }
+
+        public long HashDecrement(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashDecrement(key, hashField, value, flags);
+        }
+
+        public double HashDecrement(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashDecrement(key, hashField, value, flags);
+        }
+
+        public Task<long> HashDecrementAsync(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashDecrementAsync(key, hashField, value, flags);
+        }
+
+        public Task<double> HashDecrementAsync(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashDecrementAsync(key, hashField, value, flags);
+        }
+
+        public bool HashDelete(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashDelete(key, hashField, flags);
+        }
+
+        public long HashDelete(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashDelete(key, hashFields, flags);
+        }
+
+        public Task<bool> HashDeleteAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashDeleteAsync(key, hashField, flags);
+        }
+
+        public Task<long> HashDeleteAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashDeleteAsync(key, hashFields, flags);
+        }
+
+        public bool HashExists(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashExists(key, hashField, flags);
+        }
+
+        public Task<bool> HashExistsAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashExistsAsync(key, hashField, flags);
+        }
+
+        public ExpireResult[] HashFieldExpire(RedisKey key, RedisValue[] hashFields, TimeSpan expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldExpire(key, hashFields, expiry, when, flags);
+        }
+
+        public ExpireResult[] HashFieldExpire(RedisKey key, RedisValue[] hashFields, DateTime expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldExpire(key, hashFields, expiry, when, flags);
+        }
+
+        public Task<ExpireResult[]> HashFieldExpireAsync(RedisKey key, RedisValue[] hashFields, TimeSpan expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldExpireAsync(key, hashFields, expiry, when, flags);
+        }
+
+        public Task<ExpireResult[]> HashFieldExpireAsync(RedisKey key, RedisValue[] hashFields, DateTime expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldExpireAsync(key, hashFields, expiry, when, flags);
+        }
+
+        public long[] HashFieldGetExpireDateTime(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldGetExpireDateTime(key, hashFields, flags);
+        }
+
+        public Task<long[]> HashFieldGetExpireDateTimeAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldGetExpireDateTimeAsync(key, hashFields, flags);
+        }
+
+        public long[] HashFieldGetTimeToLive(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldGetTimeToLive(key, hashFields, flags);
+        }
+
+        public Task<long[]> HashFieldGetTimeToLiveAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldGetTimeToLiveAsync(key, hashFields, flags);
+        }
+
+        public PersistResult[] HashFieldPersist(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldPersist(key, hashFields, flags);
+        }
+
+        public Task<PersistResult[]> HashFieldPersistAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashFieldPersistAsync(key, hashFields, flags);
+        }
+
+        public RedisValue HashGet(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashGet(key, hashField, flags);
+        }
+
+        public RedisValue[] HashGet(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashGet(key, hashFields, flags);
+        }
+
+        public HashEntry[] HashGetAll(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashGetAll(key, flags);
+        }
+
+        public Task<HashEntry[]> HashGetAllAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashGetAllAsync(key, flags);
+        }
+
+        public Task<RedisValue> HashGetAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashGetAsync(key, hashField, flags);
+        }
+
+        public Task<RedisValue[]> HashGetAsync(RedisKey key, RedisValue[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashGetAsync(key, hashFields, flags);
+        }
+
+        public Lease<byte>? HashGetLease(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashGetLease(key, hashField, flags);
+        }
+
+        public Task<Lease<byte>?> HashGetLeaseAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashGetLeaseAsync(key, hashField, flags);
+        }
+
+        public long HashIncrement(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashIncrement(key, hashField, value, flags);
+        }
+
+        public double HashIncrement(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashIncrement(key, hashField, value, flags);
+        }
+
+        public Task<long> HashIncrementAsync(RedisKey key, RedisValue hashField, long value = 1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashIncrementAsync(key, hashField, value, flags);
+        }
+
+        public Task<double> HashIncrementAsync(RedisKey key, RedisValue hashField, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashIncrementAsync(key, hashField, value, flags);
+        }
+
+        public RedisValue[] HashKeys(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashKeys(key, flags);
+        }
+
+        public Task<RedisValue[]> HashKeysAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashKeysAsync(key, flags);
+        }
+
+        public long HashLength(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashLength(key, flags);
+        }
+
+        public Task<long> HashLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashLengthAsync(key, flags);
+        }
+
+        public RedisValue HashRandomField(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashRandomField(key, flags);
+        }
+
+        public Task<RedisValue> HashRandomFieldAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashRandomFieldAsync(key, flags);
+        }
+
+        public RedisValue[] HashRandomFields(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashRandomFields(key, count, flags);
+        }
+
+        public Task<RedisValue[]> HashRandomFieldsAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashRandomFieldsAsync(key, count, flags);
+        }
+
+        public HashEntry[] HashRandomFieldsWithValues(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashRandomFieldsWithValues(key, count, flags);
+        }
+
+        public Task<HashEntry[]> HashRandomFieldsWithValuesAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashRandomFieldsWithValuesAsync(key, count, flags);
+        }
+
+        public IEnumerable<HashEntry> HashScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags)
+        {
+            return _db.HashScan(key, pattern, pageSize, flags);
+        }
+
+        public IEnumerable<HashEntry> HashScan(RedisKey key, RedisValue pattern = default, int pageSize = 250, long cursor = 0, int pageOffset = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashScan(key, pattern, pageSize, cursor, pageOffset, flags);
+        }
+
+        public IAsyncEnumerable<HashEntry> HashScanAsync(RedisKey key, RedisValue pattern = default, int pageSize = 250, long cursor = 0, int pageOffset = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashScanAsync(key, pattern, pageSize, cursor, pageOffset, flags);
+        }
+
+        public IEnumerable<RedisValue> HashScanNoValues(RedisKey key, RedisValue pattern = default, int pageSize = 250, long cursor = 0, int pageOffset = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashScanNoValues(key, pattern, pageSize, cursor, pageOffset, flags);
+        }
+
+        public IAsyncEnumerable<RedisValue> HashScanNoValuesAsync(RedisKey key, RedisValue pattern = default, int pageSize = 250, long cursor = 0, int pageOffset = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashScanNoValuesAsync(key, pattern, pageSize, cursor, pageOffset, flags);
+        }
+
+        public void HashSet(RedisKey key, HashEntry[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            _db.HashSet(key, hashFields, flags);
+        }
+
+        public bool HashSet(RedisKey key, RedisValue hashField, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashSet(key, hashField, value, when, flags);
+        }
+
+        public Task HashSetAsync(RedisKey key, HashEntry[] hashFields, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashSetAsync(key, hashFields, flags);
+        }
+
+        public Task<bool> HashSetAsync(RedisKey key, RedisValue hashField, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashSetAsync(key, hashField, value, when, flags);
+        }
+
+        public long HashStringLength(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashStringLength(key, hashField, flags);
+        }
+
+        public Task<long> HashStringLengthAsync(RedisKey key, RedisValue hashField, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashStringLengthAsync(key, hashField, flags);
+        }
+
+        public RedisValue[] HashValues(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashValues(key, flags);
+        }
+
+        public Task<RedisValue[]> HashValuesAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HashValuesAsync(key, flags);
+        }
+
+        public bool HyperLogLogAdd(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogAdd(key, value, flags);
+        }
+
+        public bool HyperLogLogAdd(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogAdd(key, values, flags);
+        }
+
+        public Task<bool> HyperLogLogAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogAddAsync(key, value, flags);
+        }
+
+        public Task<bool> HyperLogLogAddAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogAddAsync(key, values, flags);
+        }
+
+        public long HyperLogLogLength(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogLength(key, flags);
+        }
+
+        public long HyperLogLogLength(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogLength(keys, flags);
+        }
+
+        public Task<long> HyperLogLogLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogLengthAsync(key, flags);
+        }
+
+        public Task<long> HyperLogLogLengthAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogLengthAsync(keys, flags);
+        }
+
+        public void HyperLogLogMerge(RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            _db.HyperLogLogMerge(destination, first, second, flags);
+        }
+
+        public void HyperLogLogMerge(RedisKey destination, RedisKey[] sourceKeys, CommandFlags flags = CommandFlags.None)
+        {
+            _db.HyperLogLogMerge(destination, sourceKeys, flags);
+        }
+
+        public Task HyperLogLogMergeAsync(RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogMergeAsync(destination, first, second, flags);
+        }
+
+        public Task HyperLogLogMergeAsync(RedisKey destination, RedisKey[] sourceKeys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.HyperLogLogMergeAsync(destination, sourceKeys, flags);
+        }
+
+        public EndPoint? IdentifyEndpoint(RedisKey key = default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.IdentifyEndpoint(key, flags);
+        }
+
+        public Task<EndPoint?> IdentifyEndpointAsync(RedisKey key = default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.IdentifyEndpointAsync(key, flags);
+        }
+
+        public bool IsConnected(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.IsConnected(key, flags);
+        }
+
+        public bool KeyCopy(RedisKey sourceKey, RedisKey destinationKey, int destinationDatabase = -1, bool replace = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyCopy(sourceKey, destinationKey, destinationDatabase, replace, flags);
+        }
+
+        public Task<bool> KeyCopyAsync(RedisKey sourceKey, RedisKey destinationKey, int destinationDatabase = -1, bool replace = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyCopyAsync(sourceKey, destinationKey, destinationDatabase, replace, flags);
+        }
+
+        public bool KeyDelete(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyDelete(key, flags);
+        }
+
+        public long KeyDelete(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyDelete(keys, flags);
+        }
+
+        public Task<bool> KeyDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyDeleteAsync(key, flags);
+        }
+
+        public Task<long> KeyDeleteAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyDeleteAsync(keys, flags);
+        }
+
+        public byte[]? KeyDump(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyDump(key, flags);
+        }
+
+        public Task<byte[]?> KeyDumpAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyDumpAsync(key, flags);
+        }
+
+        public string? KeyEncoding(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyEncoding(key, flags);
+        }
+
+        public Task<string?> KeyEncodingAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyEncodingAsync(key, flags);
+        }
+
+        public bool KeyExists(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExists(key, flags);
+        }
+
+        public long KeyExists(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExists(keys, flags);
+        }
+
+        public Task<bool> KeyExistsAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExistsAsync(key, flags);
+        }
+
+        public Task<long> KeyExistsAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExistsAsync(keys, flags);
+        }
+
+        public bool KeyExpire(RedisKey key, TimeSpan? expiry, CommandFlags flags)
+        {
+            return _db.KeyExpire(key, expiry, flags);
+        }
+
+        public bool KeyExpire(RedisKey key, TimeSpan? expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExpire(key, expiry, when, flags);
+        }
+
+        public bool KeyExpire(RedisKey key, DateTime? expiry, CommandFlags flags)
+        {
+            return _db.KeyExpire(key, expiry, flags);
+        }
+
+        public bool KeyExpire(RedisKey key, DateTime? expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExpire(key, expiry, when, flags);
+        }
+
+        public Task<bool> KeyExpireAsync(RedisKey key, TimeSpan? expiry, CommandFlags flags)
+        {
+            return _db.KeyExpireAsync(key, expiry, flags);
+        }
+
+        public Task<bool> KeyExpireAsync(RedisKey key, TimeSpan? expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExpireAsync(key, expiry, when, flags);
+        }
+
+        public Task<bool> KeyExpireAsync(RedisKey key, DateTime? expiry, CommandFlags flags)
+        {
+            return _db.KeyExpireAsync(key, expiry, flags);
+        }
+
+        public Task<bool> KeyExpireAsync(RedisKey key, DateTime? expiry, ExpireWhen when = ExpireWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExpireAsync(key, expiry, when, flags);
+        }
+
+        public DateTime? KeyExpireTime(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExpireTime(key, flags);
+        }
+
+        public Task<DateTime?> KeyExpireTimeAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyExpireTimeAsync(key, flags);
+        }
+
+        public long? KeyFrequency(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyFrequency(key, flags);
+        }
+
+        public Task<long?> KeyFrequencyAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyFrequencyAsync(key, flags);
+        }
+
+        public TimeSpan? KeyIdleTime(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyIdleTime(key, flags);
+        }
+
+        public Task<TimeSpan?> KeyIdleTimeAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyIdleTimeAsync(key, flags);
+        }
+
+        public void KeyMigrate(RedisKey key, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None)
+        {
+            _db.KeyMigrate(key, toServer, toDatabase, timeoutMilliseconds, migrateOptions, flags);
+        }
+
+        public Task KeyMigrateAsync(RedisKey key, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyMigrateAsync(key, toServer, toDatabase, timeoutMilliseconds, migrateOptions, flags);
+        }
+
+        public bool KeyMove(RedisKey key, int database, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyMove(key, database, flags);
+        }
+
+        public Task<bool> KeyMoveAsync(RedisKey key, int database, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyMoveAsync(key, database, flags);
+        }
+
+        public bool KeyPersist(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyPersist(key, flags);
+        }
+
+        public Task<bool> KeyPersistAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyPersistAsync(key, flags);
+        }
+
+        public RedisKey KeyRandom(CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyRandom(flags);
+        }
+
+        public Task<RedisKey> KeyRandomAsync(CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyRandomAsync(flags);
+        }
+
+        public long? KeyRefCount(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyRefCount(key, flags);
+        }
+
+        public Task<long?> KeyRefCountAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyRefCountAsync(key, flags);
+        }
+
+        public bool KeyRename(RedisKey key, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyRename(key, newKey, when, flags);
+        }
+
+        public Task<bool> KeyRenameAsync(RedisKey key, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyRenameAsync(key, newKey, when, flags);
+        }
+
+        public void KeyRestore(RedisKey key, byte[] value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        {
+            _db.KeyRestore(key, value, expiry, flags);
+        }
+
+        public Task KeyRestoreAsync(RedisKey key, byte[] value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyRestoreAsync(key, value, expiry, flags);
+        }
+
+        public TimeSpan? KeyTimeToLive(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyTimeToLive(key, flags);
+        }
+
+        public Task<TimeSpan?> KeyTimeToLiveAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyTimeToLiveAsync(key, flags);
+        }
+
+        public bool KeyTouch(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyTouch(key, flags);
+        }
+
+        public long KeyTouch(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyTouch(keys, flags);
+        }
+
+        public Task<bool> KeyTouchAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyTouchAsync(key, flags);
+        }
+
+        public Task<long> KeyTouchAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyTouchAsync(keys, flags);
+        }
+
+        public RedisType KeyType(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyType(key, flags);
+        }
+
+        public Task<RedisType> KeyTypeAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.KeyTypeAsync(key, flags);
+        }
+
+        public RedisValue ListGetByIndex(RedisKey key, long index, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListGetByIndex(key, index, flags);
+        }
+
+        public Task<RedisValue> ListGetByIndexAsync(RedisKey key, long index, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListGetByIndexAsync(key, index, flags);
+        }
+
+        public long ListInsertAfter(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListInsertAfter(key, pivot, value, flags);
+        }
+
+        public Task<long> ListInsertAfterAsync(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListInsertAfterAsync(key, pivot, value, flags);
+        }
+
+        public long ListInsertBefore(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListInsertBefore(key, pivot, value, flags);
+        }
+
+        public Task<long> ListInsertBeforeAsync(RedisKey key, RedisValue pivot, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListInsertBeforeAsync(key, pivot, value, flags);
+        }
+
+        public RedisValue ListLeftPop(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPop(key, flags);
+        }
+
+        public RedisValue[] ListLeftPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPop(key, count, flags);
+        }
+
+        public ListPopResult ListLeftPop(RedisKey[] keys, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPop(keys, count, flags);
+        }
+
+        public Task<RedisValue> ListLeftPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPopAsync(key, flags);
+        }
+
+        public Task<RedisValue[]> ListLeftPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPopAsync(key, count, flags);
+        }
+
+        public Task<ListPopResult> ListLeftPopAsync(RedisKey[] keys, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPopAsync(keys, count, flags);
+        }
+
+        public long ListLeftPush(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPush(key, value, when, flags);
+        }
+
+        public long ListLeftPush(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPush(key, values, when, flags);
+        }
+
+        public long ListLeftPush(RedisKey key, RedisValue[] values, CommandFlags flags)
+        {
+            return _db.ListLeftPush(key, values, flags);
+        }
+
+        public Task<long> ListLeftPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPushAsync(key, value, when, flags);
+        }
+
+        public Task<long> ListLeftPushAsync(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLeftPushAsync(key, values, when, flags);
+        }
+
+        public Task<long> ListLeftPushAsync(RedisKey key, RedisValue[] values, CommandFlags flags)
+        {
+            return _db.ListLeftPushAsync(key, values, flags);
+        }
+
+        public long ListLength(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLength(key, flags);
+        }
+
+        public Task<long> ListLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListLengthAsync(key, flags);
+        }
+
+        public RedisValue ListMove(RedisKey sourceKey, RedisKey destinationKey, ListSide sourceSide, ListSide destinationSide, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListMove(sourceKey, destinationKey, sourceSide, destinationSide, flags);
+        }
+
+        public Task<RedisValue> ListMoveAsync(RedisKey sourceKey, RedisKey destinationKey, ListSide sourceSide, ListSide destinationSide, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListMoveAsync(sourceKey, destinationKey, sourceSide, destinationSide, flags);
+        }
+
+        public long ListPosition(RedisKey key, RedisValue element, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListPosition(key, element, rank, maxLength, flags);
+        }
+
+        public Task<long> ListPositionAsync(RedisKey key, RedisValue element, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListPositionAsync(key, element, rank, maxLength, flags);
+        }
+
+        public long[] ListPositions(RedisKey key, RedisValue element, long count, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListPositions(key, element, count, rank, maxLength, flags);
+        }
+
+        public Task<long[]> ListPositionsAsync(RedisKey key, RedisValue element, long count, long rank = 1, long maxLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListPositionsAsync(key, element, count, rank, maxLength, flags);
+        }
+
+        public RedisValue[] ListRange(RedisKey key, long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRange(key, start, stop, flags);
+        }
+
+        public Task<RedisValue[]> ListRangeAsync(RedisKey key, long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRangeAsync(key, start, stop, flags);
+        }
+
+        public long ListRemove(RedisKey key, RedisValue value, long count = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRemove(key, value, count, flags);
+        }
+
+        public Task<long> ListRemoveAsync(RedisKey key, RedisValue value, long count = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRemoveAsync(key, value, count, flags);
+        }
+
+        public RedisValue ListRightPop(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPop(key, flags);
+        }
+
+        public RedisValue[] ListRightPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPop(key, count, flags);
+        }
+
+        public ListPopResult ListRightPop(RedisKey[] keys, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPop(keys, count, flags);
+        }
+
+        public Task<RedisValue> ListRightPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPopAsync(key, flags);
+        }
+
+        public Task<RedisValue[]> ListRightPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPopAsync(key, count, flags);
+        }
+
+        public Task<ListPopResult> ListRightPopAsync(RedisKey[] keys, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPopAsync(keys, count, flags);
+        }
+
+        public RedisValue ListRightPopLeftPush(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPopLeftPush(source, destination, flags);
+        }
+
+        public Task<RedisValue> ListRightPopLeftPushAsync(RedisKey source, RedisKey destination, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPopLeftPushAsync(source, destination, flags);
+        }
+
+        public long ListRightPush(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPush(key, value, when, flags);
+        }
+
+        public long ListRightPush(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPush(key, values, when, flags);
+        }
+
+        public long ListRightPush(RedisKey key, RedisValue[] values, CommandFlags flags)
+        {
+            return _db.ListRightPush(key, values, flags);
+        }
+
+        public Task<long> ListRightPushAsync(RedisKey key, RedisValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPushAsync(key, value, when, flags);
+        }
+
+        public Task<long> ListRightPushAsync(RedisKey key, RedisValue[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListRightPushAsync(key, values, when, flags);
+        }
+
+        public Task<long> ListRightPushAsync(RedisKey key, RedisValue[] values, CommandFlags flags)
+        {
+            return _db.ListRightPushAsync(key, values, flags);
+        }
+
+        public void ListSetByIndex(RedisKey key, long index, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            _db.ListSetByIndex(key, index, value, flags);
+        }
+
+        public Task ListSetByIndexAsync(RedisKey key, long index, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListSetByIndexAsync(key, index, value, flags);
+        }
+
+        public void ListTrim(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None)
+        {
+            _db.ListTrim(key, start, stop, flags);
+        }
+
+        public Task ListTrimAsync(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ListTrimAsync(key, start, stop, flags);
+        }
+
+        public bool LockExtend(RedisKey key, RedisValue value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.LockExtend(key, value, expiry, flags);
+        }
+
+        public Task<bool> LockExtendAsync(RedisKey key, RedisValue value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.LockExtendAsync(key, value, expiry, flags);
+        }
+
+        public RedisValue LockQuery(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.LockQuery(key, flags);
+        }
+
+        public Task<RedisValue> LockQueryAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.LockQueryAsync(key, flags);
+        }
+
+        public bool LockRelease(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.LockRelease(key, value, flags);
+        }
+
+        public Task<bool> LockReleaseAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.LockReleaseAsync(key, value, flags);
+        }
+
+        public bool LockTake(RedisKey key, RedisValue value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.LockTake(key, value, expiry, flags);
+        }
+
+        public Task<bool> LockTakeAsync(RedisKey key, RedisValue value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.LockTakeAsync(key, value, expiry, flags);
+        }
+
+        public TimeSpan Ping(CommandFlags flags = CommandFlags.None)
+        {
+            return _db.Ping(flags);
+        }
+
+        public Task<TimeSpan> PingAsync(CommandFlags flags = CommandFlags.None)
+        {
+            return _db.PingAsync(flags);
+        }
+
+        public long Publish(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.Publish(channel, message, flags);
+        }
+
+        public Task<long> PublishAsync(RedisChannel channel, RedisValue message, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.PublishAsync(channel, message, flags);
+        }
+
+        public RedisResult ScriptEvaluate(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluate(script, keys, values, flags);
+        }
+
+        public RedisResult ScriptEvaluate(byte[] hash, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluate(hash, keys, values, flags);
+        }
+
+        public RedisResult ScriptEvaluate(LuaScript script, object? parameters = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluate(script, parameters, flags);
+        }
+
+        public RedisResult ScriptEvaluate(LoadedLuaScript script, object? parameters = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluate(script, parameters, flags);
+        }
+
+        public Task<RedisResult> ScriptEvaluateAsync(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluateAsync(script, keys, values, flags);
+        }
+
+        public Task<RedisResult> ScriptEvaluateAsync(byte[] hash, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluateAsync(hash, keys, values, flags);
+        }
+
+        public Task<RedisResult> ScriptEvaluateAsync(LuaScript script, object? parameters = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluateAsync(script, parameters, flags);
+        }
+
+        public Task<RedisResult> ScriptEvaluateAsync(LoadedLuaScript script, object? parameters = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluateAsync(script, parameters, flags);
+        }
+
+        public RedisResult ScriptEvaluateReadOnly(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluateReadOnly(script, keys, values, flags);
+        }
+
+        public RedisResult ScriptEvaluateReadOnly(byte[] hash, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluateReadOnly(hash, keys, values, flags);
+        }
+
+        public Task<RedisResult> ScriptEvaluateReadOnlyAsync(string script, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluateReadOnlyAsync(script, keys, values, flags);
+        }
+
+        public Task<RedisResult> ScriptEvaluateReadOnlyAsync(byte[] hash, RedisKey[]? keys = null, RedisValue[]? values = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.ScriptEvaluateReadOnlyAsync(hash, keys, values, flags);
+        }
+
+        public bool SetAdd(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetAdd(key, value, flags);
+        }
+
+        public long SetAdd(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetAdd(key, values, flags);
+        }
+
+        public Task<bool> SetAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetAddAsync(key, value, flags);
+        }
+
+        public Task<long> SetAddAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetAddAsync(key, values, flags);
+        }
+
+        public RedisValue[] SetCombine(SetOperation operation, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetCombine(operation, first, second, flags);
+        }
+
+        public RedisValue[] SetCombine(SetOperation operation, RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetCombine(operation, keys, flags);
+        }
+
+        public long SetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetCombineAndStore(operation, destination, first, second, flags);
+        }
+
+        public long SetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetCombineAndStore(operation, destination, keys, flags);
+        }
+
+        public Task<long> SetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetCombineAndStoreAsync(operation, destination, first, second, flags);
+        }
+
+        public Task<long> SetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetCombineAndStoreAsync(operation, destination, keys, flags);
+        }
+
+        public Task<RedisValue[]> SetCombineAsync(SetOperation operation, RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetCombineAsync(operation, first, second, flags);
+        }
+
+        public Task<RedisValue[]> SetCombineAsync(SetOperation operation, RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetCombineAsync(operation, keys, flags);
+        }
+
+        public bool SetContains(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetContains(key, value, flags);
+        }
+
+        public bool[] SetContains(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetContains(key, values, flags);
+        }
+
+        public Task<bool> SetContainsAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetContainsAsync(key, value, flags);
+        }
+
+        public Task<bool[]> SetContainsAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetContainsAsync(key, values, flags);
+        }
+
+        public long SetIntersectionLength(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetIntersectionLength(keys, limit, flags);
+        }
+
+        public Task<long> SetIntersectionLengthAsync(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetIntersectionLengthAsync(keys, limit, flags);
+        }
+
+        public long SetLength(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetLength(key, flags);
+        }
+
+        public Task<long> SetLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetLengthAsync(key, flags);
+        }
+
+        public RedisValue[] SetMembers(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetMembers(key, flags);
+        }
+
+        public Task<RedisValue[]> SetMembersAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetMembersAsync(key, flags);
+        }
+
+        public bool SetMove(RedisKey source, RedisKey destination, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetMove(source, destination, value, flags);
+        }
+
+        public Task<bool> SetMoveAsync(RedisKey source, RedisKey destination, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetMoveAsync(source, destination, value, flags);
+        }
+
+        public RedisValue SetPop(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetPop(key, flags);
+        }
+
+        public RedisValue[] SetPop(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetPop(key, count, flags);
+        }
+
+        public Task<RedisValue> SetPopAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetPopAsync(key, flags);
+        }
+
+        public Task<RedisValue[]> SetPopAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetPopAsync(key, count, flags);
+        }
+
+        public RedisValue SetRandomMember(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetRandomMember(key, flags);
+        }
+
+        public Task<RedisValue> SetRandomMemberAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetRandomMemberAsync(key, flags);
+        }
+
+        public RedisValue[] SetRandomMembers(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetRandomMembers(key, count, flags);
+        }
+
+        public Task<RedisValue[]> SetRandomMembersAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetRandomMembersAsync(key, count, flags);
+        }
+
+        public bool SetRemove(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetRemove(key, value, flags);
+        }
+
+        public long SetRemove(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetRemove(key, values, flags);
+        }
+
+        public Task<bool> SetRemoveAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetRemoveAsync(key, value, flags);
+        }
+
+        public Task<long> SetRemoveAsync(RedisKey key, RedisValue[] values, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetRemoveAsync(key, values, flags);
+        }
+
+        public IEnumerable<RedisValue> SetScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags)
+        {
+            return _db.SetScan(key, pattern, pageSize, flags);
+        }
+
+        public IEnumerable<RedisValue> SetScan(RedisKey key, RedisValue pattern = default, int pageSize = 250, long cursor = 0, int pageOffset = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetScan(key, pattern, pageSize, cursor, pageOffset, flags);
+        }
+
+        public IAsyncEnumerable<RedisValue> SetScanAsync(RedisKey key, RedisValue pattern = default, int pageSize = 250, long cursor = 0, int pageOffset = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SetScanAsync(key, pattern, pageSize, cursor, pageOffset, flags);
+        }
+
+        public RedisValue[] Sort(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.Sort(key, skip, take, order, sortType, by, get, flags);
+        }
+
+        public long SortAndStore(RedisKey destination, RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortAndStore(destination, key, skip, take, order, sortType, by, get, flags);
+        }
+
+        public Task<long> SortAndStoreAsync(RedisKey destination, RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortAndStoreAsync(destination, key, skip, take, order, sortType, by, get, flags);
+        }
+
+        public Task<RedisValue[]> SortAsync(RedisKey key, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, RedisValue by = default, RedisValue[]? get = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortAsync(key, skip, take, order, sortType, by, get, flags);
+        }
+
+        public bool SortedSetAdd(RedisKey key, RedisValue member, double score, CommandFlags flags)
+        {
+            return _db.SortedSetAdd(key, member, score, flags);
+        }
+
+        public bool SortedSetAdd(RedisKey key, RedisValue member, double score, When when, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetAdd(key, member, score, when, flags);
+        }
+
+        public bool SortedSetAdd(RedisKey key, RedisValue member, double score, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetAdd(key, member, score, when, flags);
+        }
+
+        public long SortedSetAdd(RedisKey key, SortedSetEntry[] values, CommandFlags flags)
+        {
+            return _db.SortedSetAdd(key, values, flags);
+        }
+
+        public long SortedSetAdd(RedisKey key, SortedSetEntry[] values, When when, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetAdd(key, values, when, flags);
+        }
+
+        public long SortedSetAdd(RedisKey key, SortedSetEntry[] values, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetAdd(key, values, when, flags);
+        }
+
+        public Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, CommandFlags flags)
+        {
+            return _db.SortedSetAddAsync(key, member, score, flags);
+        }
+
+        public Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, When when, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetAddAsync(key, member, score, when, flags);
+        }
+
+        public Task<bool> SortedSetAddAsync(RedisKey key, RedisValue member, double score, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetAddAsync(key, member, score, when, flags);
+        }
+
+        public Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, CommandFlags flags)
+        {
+            return _db.SortedSetAddAsync(key, values, flags);
+        }
+
+        public Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, When when, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetAddAsync(key, values, when, flags);
+        }
+
+        public Task<long> SortedSetAddAsync(RedisKey key, SortedSetEntry[] values, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetAddAsync(key, values, when, flags);
+        }
+
+        public RedisValue[] SortedSetCombine(SetOperation operation, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetCombine(operation, keys, weights, aggregate, flags);
+        }
+
+        public long SortedSetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetCombineAndStore(operation, destination, first, second, aggregate, flags);
+        }
+
+        public long SortedSetCombineAndStore(SetOperation operation, RedisKey destination, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetCombineAndStore(operation, destination, keys, weights, aggregate, flags);
+        }
+
+        public Task<long> SortedSetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey first, RedisKey second, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetCombineAndStoreAsync(operation, destination, first, second, aggregate, flags);
+        }
+
+        public Task<long> SortedSetCombineAndStoreAsync(SetOperation operation, RedisKey destination, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetCombineAndStoreAsync(operation, destination, keys, weights, aggregate, flags);
+        }
+
+        public Task<RedisValue[]> SortedSetCombineAsync(SetOperation operation, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetCombineAsync(operation, keys, weights, aggregate, flags);
+        }
+
+        public SortedSetEntry[] SortedSetCombineWithScores(SetOperation operation, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetCombineWithScores(operation, keys, weights, aggregate, flags);
+        }
+
+        public Task<SortedSetEntry[]> SortedSetCombineWithScoresAsync(SetOperation operation, RedisKey[] keys, double[]? weights = null, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetCombineWithScoresAsync(operation, keys, weights, aggregate, flags);
+        }
+
+        public double SortedSetDecrement(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetDecrement(key, member, value, flags);
+        }
+
+        public Task<double> SortedSetDecrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetDecrementAsync(key, member, value, flags);
+        }
+
+        public double SortedSetIncrement(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetIncrement(key, member, value, flags);
+        }
+
+        public Task<double> SortedSetIncrementAsync(RedisKey key, RedisValue member, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetIncrementAsync(key, member, value, flags);
+        }
+
+        public long SortedSetIntersectionLength(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetIntersectionLength(keys, limit, flags);
+        }
+
+        public Task<long> SortedSetIntersectionLengthAsync(RedisKey[] keys, long limit = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetIntersectionLengthAsync(keys, limit, flags);
+        }
+
+        public long SortedSetLength(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetLength(key, min, max, exclude, flags);
+        }
+
+        public Task<long> SortedSetLengthAsync(RedisKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetLengthAsync(key, min, max, exclude, flags);
+        }
+
+        public long SortedSetLengthByValue(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetLengthByValue(key, min, max, exclude, flags);
+        }
+
+        public Task<long> SortedSetLengthByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetLengthByValueAsync(key, min, max, exclude, flags);
+        }
+
+        public SortedSetEntry? SortedSetPop(RedisKey key, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetPop(key, order, flags);
+        }
+
+        public SortedSetEntry[] SortedSetPop(RedisKey key, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetPop(key, count, order, flags);
+        }
+
+        public SortedSetPopResult SortedSetPop(RedisKey[] keys, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetPop(keys, count, order, flags);
+        }
+
+        public Task<SortedSetEntry?> SortedSetPopAsync(RedisKey key, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetPopAsync(key, order, flags);
+        }
+
+        public Task<SortedSetEntry[]> SortedSetPopAsync(RedisKey key, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetPopAsync(key, count, order, flags);
+        }
+
+        public Task<SortedSetPopResult> SortedSetPopAsync(RedisKey[] keys, long count, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetPopAsync(keys, count, order, flags);
+        }
+
+        public RedisValue SortedSetRandomMember(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRandomMember(key, flags);
+        }
+
+        public Task<RedisValue> SortedSetRandomMemberAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRandomMemberAsync(key, flags);
+        }
+
+        public RedisValue[] SortedSetRandomMembers(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRandomMembers(key, count, flags);
+        }
+
+        public Task<RedisValue[]> SortedSetRandomMembersAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRandomMembersAsync(key, count, flags);
+        }
+
+        public SortedSetEntry[] SortedSetRandomMembersWithScores(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRandomMembersWithScores(key, count, flags);
+        }
+
+        public Task<SortedSetEntry[]> SortedSetRandomMembersWithScoresAsync(RedisKey key, long count, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRandomMembersWithScoresAsync(key, count, flags);
+        }
+
+        public long SortedSetRangeAndStore(RedisKey sourceKey, RedisKey destinationKey, RedisValue start, RedisValue stop, SortedSetOrder sortedSetOrder = SortedSetOrder.ByRank, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long? take = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeAndStore(sourceKey, destinationKey, start, stop, sortedSetOrder, exclude, order, skip, take, flags);
+        }
+
+        public Task<long> SortedSetRangeAndStoreAsync(RedisKey sourceKey, RedisKey destinationKey, RedisValue start, RedisValue stop, SortedSetOrder sortedSetOrder = SortedSetOrder.ByRank, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long? take = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeAndStoreAsync(sourceKey, destinationKey, start, stop, sortedSetOrder, exclude, order, skip, take, flags);
+        }
+
+        public RedisValue[] SortedSetRangeByRank(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByRank(key, start, stop, order, flags);
+        }
+
+        public Task<RedisValue[]> SortedSetRangeByRankAsync(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByRankAsync(key, start, stop, order, flags);
+        }
+
+        public SortedSetEntry[] SortedSetRangeByRankWithScores(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByRankWithScores(key, start, stop, order, flags);
+        }
+
+        public Task<SortedSetEntry[]> SortedSetRangeByRankWithScoresAsync(RedisKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByRankWithScoresAsync(key, start, stop, order, flags);
+        }
+
+        public RedisValue[] SortedSetRangeByScore(RedisKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByScore(key, start, stop, exclude, order, skip, take, flags);
+        }
+
+        public Task<RedisValue[]> SortedSetRangeByScoreAsync(RedisKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByScoreAsync(key, start, stop, exclude, order, skip, take, flags);
+        }
+
+        public SortedSetEntry[] SortedSetRangeByScoreWithScores(RedisKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByScoreWithScores(key, start, stop, exclude, order, skip, take, flags);
+        }
+
+        public Task<SortedSetEntry[]> SortedSetRangeByScoreWithScoresAsync(RedisKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByScoreWithScoresAsync(key, start, stop, exclude, order, skip, take, flags);
+        }
+
+        public RedisValue[] SortedSetRangeByValue(RedisKey key, RedisValue min, RedisValue max, Exclude exclude, long skip, long take = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByValue(key, min, max, exclude, skip, take, flags);
+        }
+
+        public RedisValue[] SortedSetRangeByValue(RedisKey key, RedisValue min = default, RedisValue max = default, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByValue(key, min, max, exclude, order, skip, take, flags);
+        }
+
+        public Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude, long skip, long take = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByValueAsync(key, min, max, exclude, skip, take, flags);
+        }
+
+        public Task<RedisValue[]> SortedSetRangeByValueAsync(RedisKey key, RedisValue min = default, RedisValue max = default, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRangeByValueAsync(key, min, max, exclude, order, skip, take, flags);
+        }
+
+        public long? SortedSetRank(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRank(key, member, order, flags);
+        }
+
+        public Task<long?> SortedSetRankAsync(RedisKey key, RedisValue member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRankAsync(key, member, order, flags);
+        }
+
+        public bool SortedSetRemove(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemove(key, member, flags);
+        }
+
+        public long SortedSetRemove(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemove(key, members, flags);
+        }
+
+        public Task<bool> SortedSetRemoveAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemoveAsync(key, member, flags);
+        }
+
+        public Task<long> SortedSetRemoveAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemoveAsync(key, members, flags);
+        }
+
+        public long SortedSetRemoveRangeByRank(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemoveRangeByRank(key, start, stop, flags);
+        }
+
+        public Task<long> SortedSetRemoveRangeByRankAsync(RedisKey key, long start, long stop, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemoveRangeByRankAsync(key, start, stop, flags);
+        }
+
+        public long SortedSetRemoveRangeByScore(RedisKey key, double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemoveRangeByScore(key, start, stop, exclude, flags);
+        }
+
+        public Task<long> SortedSetRemoveRangeByScoreAsync(RedisKey key, double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemoveRangeByScoreAsync(key, start, stop, exclude, flags);
+        }
+
+        public long SortedSetRemoveRangeByValue(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemoveRangeByValue(key, min, max, exclude, flags);
+        }
+
+        public Task<long> SortedSetRemoveRangeByValueAsync(RedisKey key, RedisValue min, RedisValue max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetRemoveRangeByValueAsync(key, min, max, exclude, flags);
+        }
+
+        public IEnumerable<SortedSetEntry> SortedSetScan(RedisKey key, RedisValue pattern, int pageSize, CommandFlags flags)
+        {
+            return _db.SortedSetScan(key, pattern, pageSize, flags);
+        }
+
+        public IEnumerable<SortedSetEntry> SortedSetScan(RedisKey key, RedisValue pattern = default, int pageSize = 250, long cursor = 0, int pageOffset = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetScan(key, pattern, pageSize, cursor, pageOffset, flags);
+        }
+
+        public IAsyncEnumerable<SortedSetEntry> SortedSetScanAsync(RedisKey key, RedisValue pattern = default, int pageSize = 250, long cursor = 0, int pageOffset = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetScanAsync(key, pattern, pageSize, cursor, pageOffset, flags);
+        }
+
+        public double? SortedSetScore(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetScore(key, member, flags);
+        }
+
+        public Task<double?> SortedSetScoreAsync(RedisKey key, RedisValue member, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetScoreAsync(key, member, flags);
+        }
+
+        public double?[] SortedSetScores(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetScores(key, members, flags);
+        }
+
+        public Task<double?[]> SortedSetScoresAsync(RedisKey key, RedisValue[] members, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetScoresAsync(key, members, flags);
+        }
+
+        public bool SortedSetUpdate(RedisKey key, RedisValue member, double score, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetUpdate(key, member, score, when, flags);
+        }
+
+        public long SortedSetUpdate(RedisKey key, SortedSetEntry[] values, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetUpdate(key, values, when, flags);
+        }
+
+        public Task<bool> SortedSetUpdateAsync(RedisKey key, RedisValue member, double score, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetUpdateAsync(key, member, score, when, flags);
+        }
+
+        public Task<long> SortedSetUpdateAsync(RedisKey key, SortedSetEntry[] values, SortedSetWhen when = SortedSetWhen.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.SortedSetUpdateAsync(key, values, when, flags);
+        }
+
+        public long StreamAcknowledge(RedisKey key, RedisValue groupName, RedisValue messageId, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAcknowledge(key, groupName, messageId, flags);
+        }
+
+        public long StreamAcknowledge(RedisKey key, RedisValue groupName, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAcknowledge(key, groupName, messageIds, flags);
+        }
+
+        public Task<long> StreamAcknowledgeAsync(RedisKey key, RedisValue groupName, RedisValue messageId, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAcknowledgeAsync(key, groupName, messageId, flags);
+        }
+
+        public Task<long> StreamAcknowledgeAsync(RedisKey key, RedisValue groupName, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAcknowledgeAsync(key, groupName, messageIds, flags);
+        }
+
+        public RedisValue StreamAdd(RedisKey key, RedisValue streamField, RedisValue streamValue, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAdd(key, streamField, streamValue, messageId, maxLength, useApproximateMaxLength, flags);
+        }
+
+        public RedisValue StreamAdd(RedisKey key, NameValueEntry[] streamPairs, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAdd(key, streamPairs, messageId, maxLength, useApproximateMaxLength, flags);
+        }
+
+        public Task<RedisValue> StreamAddAsync(RedisKey key, RedisValue streamField, RedisValue streamValue, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAddAsync(key, streamField, streamValue, messageId, maxLength, useApproximateMaxLength, flags);
+        }
+
+        public Task<RedisValue> StreamAddAsync(RedisKey key, NameValueEntry[] streamPairs, RedisValue? messageId = null, int? maxLength = null, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAddAsync(key, streamPairs, messageId, maxLength, useApproximateMaxLength, flags);
+        }
+
+        public StreamAutoClaimResult StreamAutoClaim(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue startAtId, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAutoClaim(key, consumerGroup, claimingConsumer, minIdleTimeInMs, startAtId, count, flags);
+        }
+
+        public Task<StreamAutoClaimResult> StreamAutoClaimAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue startAtId, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAutoClaimAsync(key, consumerGroup, claimingConsumer, minIdleTimeInMs, startAtId, count, flags);
+        }
+
+        public StreamAutoClaimIdsOnlyResult StreamAutoClaimIdsOnly(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue startAtId, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAutoClaimIdsOnly(key, consumerGroup, claimingConsumer, minIdleTimeInMs, startAtId, count, flags);
+        }
+
+        public Task<StreamAutoClaimIdsOnlyResult> StreamAutoClaimIdsOnlyAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue startAtId, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamAutoClaimIdsOnlyAsync(key, consumerGroup, claimingConsumer, minIdleTimeInMs, startAtId, count, flags);
+        }
+
+        public StreamEntry[] StreamClaim(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamClaim(key, consumerGroup, claimingConsumer, minIdleTimeInMs, messageIds, flags);
+        }
+
+        public Task<StreamEntry[]> StreamClaimAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamClaimAsync(key, consumerGroup, claimingConsumer, minIdleTimeInMs, messageIds, flags);
+        }
+
+        public RedisValue[] StreamClaimIdsOnly(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamClaimIdsOnly(key, consumerGroup, claimingConsumer, minIdleTimeInMs, messageIds, flags);
+        }
+
+        public Task<RedisValue[]> StreamClaimIdsOnlyAsync(RedisKey key, RedisValue consumerGroup, RedisValue claimingConsumer, long minIdleTimeInMs, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamClaimIdsOnlyAsync(key, consumerGroup, claimingConsumer, minIdleTimeInMs, messageIds, flags);
+        }
+
+        public bool StreamConsumerGroupSetPosition(RedisKey key, RedisValue groupName, RedisValue position, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamConsumerGroupSetPosition(key, groupName, position, flags);
+        }
+
+        public Task<bool> StreamConsumerGroupSetPositionAsync(RedisKey key, RedisValue groupName, RedisValue position, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamConsumerGroupSetPositionAsync(key, groupName, position, flags);
+        }
+
+        public StreamConsumerInfo[] StreamConsumerInfo(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamConsumerInfo(key, groupName, flags);
+        }
+
+        public Task<StreamConsumerInfo[]> StreamConsumerInfoAsync(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamConsumerInfoAsync(key, groupName, flags);
+        }
+
+        public bool StreamCreateConsumerGroup(RedisKey key, RedisValue groupName, RedisValue? position, CommandFlags flags)
+        {
+            return _db.StreamCreateConsumerGroup(key, groupName, position, flags);
+        }
+
+        public bool StreamCreateConsumerGroup(RedisKey key, RedisValue groupName, RedisValue? position = null, bool createStream = true, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamCreateConsumerGroup(key, groupName, position, createStream, flags);
+        }
+
+        public Task<bool> StreamCreateConsumerGroupAsync(RedisKey key, RedisValue groupName, RedisValue? position, CommandFlags flags)
+        {
+            return _db.StreamCreateConsumerGroupAsync(key, groupName, position, flags);
+        }
+
+        public Task<bool> StreamCreateConsumerGroupAsync(RedisKey key, RedisValue groupName, RedisValue? position = null, bool createStream = true, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamCreateConsumerGroupAsync(key, groupName, position, createStream, flags);
+        }
+
+        public long StreamDelete(RedisKey key, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamDelete(key, messageIds, flags);
+        }
+
+        public Task<long> StreamDeleteAsync(RedisKey key, RedisValue[] messageIds, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamDeleteAsync(key, messageIds, flags);
+        }
+
+        public long StreamDeleteConsumer(RedisKey key, RedisValue groupName, RedisValue consumerName, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamDeleteConsumer(key, groupName, consumerName, flags);
+        }
+
+        public Task<long> StreamDeleteConsumerAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamDeleteConsumerAsync(key, groupName, consumerName, flags);
+        }
+
+        public bool StreamDeleteConsumerGroup(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamDeleteConsumerGroup(key, groupName, flags);
+        }
+
+        public Task<bool> StreamDeleteConsumerGroupAsync(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamDeleteConsumerGroupAsync(key, groupName, flags);
+        }
+
+        public StreamGroupInfo[] StreamGroupInfo(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamGroupInfo(key, flags);
+        }
+
+        public Task<StreamGroupInfo[]> StreamGroupInfoAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamGroupInfoAsync(key, flags);
+        }
+
+        public StreamInfo StreamInfo(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamInfo(key, flags);
+        }
+
+        public Task<StreamInfo> StreamInfoAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamInfoAsync(key, flags);
+        }
+
+        public long StreamLength(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamLength(key, flags);
+        }
+
+        public Task<long> StreamLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamLengthAsync(key, flags);
+        }
+
+        public StreamPendingInfo StreamPending(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamPending(key, groupName, flags);
+        }
+
+        public Task<StreamPendingInfo> StreamPendingAsync(RedisKey key, RedisValue groupName, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamPendingAsync(key, groupName, flags);
+        }
+
+        public StreamPendingMessageInfo[] StreamPendingMessages(RedisKey key, RedisValue groupName, int count, RedisValue consumerName, RedisValue? minId = null, RedisValue? maxId = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamPendingMessages(key, groupName, count, consumerName, minId, maxId, flags);
+        }
+
+        public Task<StreamPendingMessageInfo[]> StreamPendingMessagesAsync(RedisKey key, RedisValue groupName, int count, RedisValue consumerName, RedisValue? minId = null, RedisValue? maxId = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamPendingMessagesAsync(key, groupName, count, consumerName, minId, maxId, flags);
+        }
+
+        public StreamEntry[] StreamRange(RedisKey key, RedisValue? minId = null, RedisValue? maxId = null, int? count = null, Order messageOrder = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamRange(key, minId, maxId, count, messageOrder, flags);
+        }
+
+        public Task<StreamEntry[]> StreamRangeAsync(RedisKey key, RedisValue? minId = null, RedisValue? maxId = null, int? count = null, Order messageOrder = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamRangeAsync(key, minId, maxId, count, messageOrder, flags);
+        }
+
+        public StreamEntry[] StreamRead(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamRead(key, position, count, flags);
+        }
+
+        public RedisStream[] StreamRead(StreamPosition[] streamPositions, int? countPerStream = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamRead(streamPositions, countPerStream, flags);
+        }
+
+        public Task<StreamEntry[]> StreamReadAsync(RedisKey key, RedisValue position, int? count = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamReadAsync(key, position, count, flags);
+        }
+
+        public Task<RedisStream[]> StreamReadAsync(StreamPosition[] streamPositions, int? countPerStream = null, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamReadAsync(streamPositions, countPerStream, flags);
+        }
+
+        public StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position, int? count, CommandFlags flags)
+        {
+            return _db.StreamReadGroup(key, groupName, consumerName, position, count, flags);
+        }
+
+        public StreamEntry[] StreamReadGroup(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamReadGroup(key, groupName, consumerName, position, count, noAck, flags);
+        }
+
+        public RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream, CommandFlags flags)
+        {
+            return _db.StreamReadGroup(streamPositions, groupName, consumerName, countPerStream, flags);
+        }
+
+        public RedisStream[] StreamReadGroup(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, bool noAck = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamReadGroup(streamPositions, groupName, consumerName, countPerStream, noAck, flags);
+        }
+
+        public Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position, int? count, CommandFlags flags)
+        {
+            return _db.StreamReadGroupAsync(key, groupName, consumerName, position, count, flags);
+        }
+
+        public Task<StreamEntry[]> StreamReadGroupAsync(RedisKey key, RedisValue groupName, RedisValue consumerName, RedisValue? position = null, int? count = null, bool noAck = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamReadGroupAsync(key, groupName, consumerName, position, count, noAck, flags);
+        }
+
+        public Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream, CommandFlags flags)
+        {
+            return _db.StreamReadGroupAsync(streamPositions, groupName, consumerName, countPerStream, flags);
+        }
+
+        public Task<RedisStream[]> StreamReadGroupAsync(StreamPosition[] streamPositions, RedisValue groupName, RedisValue consumerName, int? countPerStream = null, bool noAck = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamReadGroupAsync(streamPositions, groupName, consumerName, countPerStream, noAck, flags);
+        }
+
+        public long StreamTrim(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamTrim(key, maxLength, useApproximateMaxLength, flags);
+        }
+
+        public Task<long> StreamTrimAsync(RedisKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StreamTrimAsync(key, maxLength, useApproximateMaxLength, flags);
+        }
+
+        public long StringAppend(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringAppend(key, value, flags);
+        }
+
+        public Task<long> StringAppendAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringAppendAsync(key, value, flags);
+        }
+
+        public long StringBitCount(RedisKey key, long start, long end, CommandFlags flags)
+        {
+            return _db.StringBitCount(key, start, end, flags);
+        }
+
+        public long StringBitCount(RedisKey key, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringBitCount(key, start, end, indexType, flags);
+        }
+
+        public Task<long> StringBitCountAsync(RedisKey key, long start, long end, CommandFlags flags)
+        {
+            return _db.StringBitCountAsync(key, start, end, flags);
+        }
+
+        public Task<long> StringBitCountAsync(RedisKey key, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringBitCountAsync(key, start, end, indexType, flags);
+        }
+
+        public long StringBitOperation(Bitwise operation, RedisKey destination, RedisKey first, RedisKey second = default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringBitOperation(operation, destination, first, second, flags);
+        }
+
+        public long StringBitOperation(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringBitOperation(operation, destination, keys, flags);
+        }
+
+        public Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey first, RedisKey second = default, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringBitOperationAsync(operation, destination, first, second, flags);
+        }
+
+        public Task<long> StringBitOperationAsync(Bitwise operation, RedisKey destination, RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringBitOperationAsync(operation, destination, keys, flags);
+        }
+
+        public long StringBitPosition(RedisKey key, bool bit, long start, long end, CommandFlags flags)
+        {
+            return _db.StringBitPosition(key, bit, start, end, flags);
+        }
+
+        public long StringBitPosition(RedisKey key, bool bit, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringBitPosition(key, bit, start, end, indexType, flags);
+        }
+
+        public Task<long> StringBitPositionAsync(RedisKey key, bool bit, long start, long end, CommandFlags flags)
+        {
+            return _db.StringBitPositionAsync(key, bit, start, end, flags);
+        }
+
+        public Task<long> StringBitPositionAsync(RedisKey key, bool bit, long start = 0, long end = -1, StringIndexType indexType = StringIndexType.Byte, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringBitPositionAsync(key, bit, start, end, indexType, flags);
+        }
+
+        public long StringDecrement(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringDecrement(key, value, flags);
+        }
+
+        public double StringDecrement(RedisKey key, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringDecrement(key, value, flags);
+        }
+
+        public Task<long> StringDecrementAsync(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringDecrementAsync(key, value, flags);
+        }
+
+        public Task<double> StringDecrementAsync(RedisKey key, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringDecrementAsync(key, value, flags);
+        }
+
+        public RedisValue StringGet(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGet(key, flags);
+        }
+
+        public RedisValue[] StringGet(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGet(keys, flags);
+        }
+
+        public Task<RedisValue> StringGetAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetAsync(key, flags);
+        }
+
+        public Task<RedisValue[]> StringGetAsync(RedisKey[] keys, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetAsync(keys, flags);
+        }
+
+        public bool StringGetBit(RedisKey key, long offset, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetBit(key, offset, flags);
+        }
+
+        public Task<bool> StringGetBitAsync(RedisKey key, long offset, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetBitAsync(key, offset, flags);
+        }
+
+        public RedisValue StringGetDelete(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetDelete(key, flags);
+        }
+
+        public Task<RedisValue> StringGetDeleteAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetDeleteAsync(key, flags);
+        }
+
+        public Lease<byte>? StringGetLease(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetLease(key, flags);
+        }
+
+        public Task<Lease<byte>?> StringGetLeaseAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetLeaseAsync(key, flags);
+        }
+
+        public RedisValue StringGetRange(RedisKey key, long start, long end, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetRange(key, start, end, flags);
+        }
+
+        public Task<RedisValue> StringGetRangeAsync(RedisKey key, long start, long end, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetRangeAsync(key, start, end, flags);
+        }
+
+        public RedisValue StringGetSet(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetSet(key, value, flags);
+        }
+
+        public Task<RedisValue> StringGetSetAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetSetAsync(key, value, flags);
+        }
+
+        public RedisValue StringGetSetExpiry(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetSetExpiry(key, expiry, flags);
+        }
+
+        public RedisValue StringGetSetExpiry(RedisKey key, DateTime expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetSetExpiry(key, expiry, flags);
+        }
+
+        public Task<RedisValue> StringGetSetExpiryAsync(RedisKey key, TimeSpan? expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetSetExpiryAsync(key, expiry, flags);
+        }
+
+        public Task<RedisValue> StringGetSetExpiryAsync(RedisKey key, DateTime expiry, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetSetExpiryAsync(key, expiry, flags);
+        }
+
+        public RedisValueWithExpiry StringGetWithExpiry(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetWithExpiry(key, flags);
+        }
+
+        public Task<RedisValueWithExpiry> StringGetWithExpiryAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringGetWithExpiryAsync(key, flags);
+        }
+
+        public long StringIncrement(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringIncrement(key, value, flags);
+        }
+
+        public double StringIncrement(RedisKey key, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringIncrement(key, value, flags);
+        }
+
+        public Task<long> StringIncrementAsync(RedisKey key, long value = 1, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringIncrementAsync(key, value, flags);
+        }
+
+        public Task<double> StringIncrementAsync(RedisKey key, double value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringIncrementAsync(key, value, flags);
+        }
+
+        public long StringLength(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringLength(key, flags);
+        }
+
+        public Task<long> StringLengthAsync(RedisKey key, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringLengthAsync(key, flags);
+        }
+
+        public string? StringLongestCommonSubsequence(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringLongestCommonSubsequence(first, second, flags);
+        }
+
+        public Task<string?> StringLongestCommonSubsequenceAsync(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringLongestCommonSubsequenceAsync(first, second, flags);
+        }
+
+        public long StringLongestCommonSubsequenceLength(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringLongestCommonSubsequenceLength(first, second, flags);
+        }
+
+        public Task<long> StringLongestCommonSubsequenceLengthAsync(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringLongestCommonSubsequenceLengthAsync(first, second, flags);
+        }
+
+        public LCSMatchResult StringLongestCommonSubsequenceWithMatches(RedisKey first, RedisKey second, long minLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringLongestCommonSubsequenceWithMatches(first, second, minLength, flags);
+        }
+
+        public Task<LCSMatchResult> StringLongestCommonSubsequenceWithMatchesAsync(RedisKey first, RedisKey second, long minLength = 0, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringLongestCommonSubsequenceWithMatchesAsync(first, second, minLength, flags);
+        }
+
+        public bool StringSet(RedisKey key, RedisValue value, TimeSpan? expiry, When when)
+        {
+            return _db.StringSet(key, value, expiry, when);
+        }
+
+        public bool StringSet(RedisKey key, RedisValue value, TimeSpan? expiry, When when, CommandFlags flags)
+        {
+            return _db.StringSet(key, value, expiry, when, flags);
+        }
+
+        public bool StringSet(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSet(key, value, expiry, keepTtl, when, flags);
+        }
+
+        public bool StringSet(KeyValuePair<RedisKey, RedisValue>[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSet(values, when, flags);
+        }
+
+        public RedisValue StringSetAndGet(RedisKey key, RedisValue value, TimeSpan? expiry, When when, CommandFlags flags)
+        {
+            return _db.StringSetAndGet(key, value, expiry, when, flags);
+        }
+
+        public RedisValue StringSetAndGet(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSetAndGet(key, value, expiry, keepTtl, when, flags);
+        }
+
+        public Task<RedisValue> StringSetAndGetAsync(RedisKey key, RedisValue value, TimeSpan? expiry, When when, CommandFlags flags)
+        {
+            return _db.StringSetAndGetAsync(key, value, expiry, when, flags);
+        }
+
+        public Task<RedisValue> StringSetAndGetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSetAndGetAsync(key, value, expiry, keepTtl, when, flags);
+        }
+
+        public Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry, When when)
+        {
+            return _db.StringSetAsync(key, value, expiry, when);
+        }
+
+        public Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry, When when, CommandFlags flags)
+        {
+            return _db.StringSetAsync(key, value, expiry, when, flags);
+        }
+
+        public Task<bool> StringSetAsync(RedisKey key, RedisValue value, TimeSpan? expiry = null, bool keepTtl = false, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSetAsync(key, value, expiry, keepTtl, when, flags);
+        }
+
+        public Task<bool> StringSetAsync(KeyValuePair<RedisKey, RedisValue>[] values, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSetAsync(values, when, flags);
+        }
+
+        public bool StringSetBit(RedisKey key, long offset, bool bit, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSetBit(key, offset, bit, flags);
+        }
+
+        public Task<bool> StringSetBitAsync(RedisKey key, long offset, bool bit, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSetBitAsync(key, offset, bit, flags);
+        }
+
+        public RedisValue StringSetRange(RedisKey key, long offset, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSetRange(key, offset, value, flags);
+        }
+
+        public Task<RedisValue> StringSetRangeAsync(RedisKey key, long offset, RedisValue value, CommandFlags flags = CommandFlags.None)
+        {
+            return _db.StringSetRangeAsync(key, offset, value, flags);
+        }
+
+        public bool TryWait(Task task)
+        {
+            return _db.TryWait(task);
+        }
+
+        public void Wait(Task task)
+        {
+            _db.Wait(task);
+        }
+
+        public T Wait<T>(Task<T> task)
+        {
+            return _db.Wait(task);
+        }
+
+        public void WaitAll(params Task[] tasks)
+        {
+            _db.WaitAll(tasks);
+        }
+    }
+}

--- a/src/NRedisStack/IRedisClient.cs
+++ b/src/NRedisStack/IRedisClient.cs
@@ -1,0 +1,28 @@
+using StackExchange.Redis;
+
+namespace NRedisStack;
+
+/// <summary>
+/// This class is EXPERIMENTAL!! and may change or removed in future releases.
+/// Represents a Redis client that can connect to a Redis server 
+/// providing access to <see cref="IRedisDatabase"/> instances as well as the underlying multiplexer.
+/// </summary>
+public interface IRedisClient
+{
+    /// <summary>
+    /// Gets a database instance.
+    /// </summary>
+    /// <param name="db">The ID to get a database for.</param>
+    /// <param name="asyncState">The async state to pass into the resulting <see cref="RedisDatabase"/>.</param>
+    /// <returns></returns>
+    public IRedisDatabase GetDatabase(int db = -1, object? asyncState = null);
+
+    /// <summary>
+    /// Gets the underlying <see cref="ConnectionMultiplexer"/> instance.
+    /// </summary>
+    /// <returns></returns>
+    public IConnectionMultiplexer GetMultiplexer();
+}
+
+
+

--- a/src/NRedisStack/IRedisDatabase.cs
+++ b/src/NRedisStack/IRedisDatabase.cs
@@ -1,0 +1,60 @@
+using StackExchange.Redis;
+
+namespace NRedisStack;
+
+/// <summary>
+/// This class is EXPERIMENTAL!! and may change or removed in future releases.
+/// Interface that provides access to Redis commands
+/// including Search, JSON, TimeSeries, Bloom and more..
+/// </summary>
+public interface IRedisDatabase : IDatabase
+{
+    /// <summary>
+    /// Gets a command set for interacting with the RedisBloom Bloom Filter module.
+    /// </summary>
+    /// <returns>Command set for Bloom Filter operations.</returns>
+    public BloomCommands BF();
+
+    /// <summary>
+    /// Gets a command set for interacting with the RedisBloom Count-Min Sketch module.
+    /// </summary>
+    /// <returns>Command set for Count-Min Sketch operations.</returns>
+    public CmsCommands CMS();
+
+    /// <summary>
+    /// Gets a command set for interacting with the RedisBloom Cuckoo Filter module.
+    /// </summary>
+    /// <returns>Command set for Cuckoo Filter operations.</returns>
+    public CuckooCommands CF();
+
+    /// <summary>
+    /// Gets a command set for interacting with the RedisJSON module.
+    /// </summary>
+    /// <returns>Command set for JSON operations.</returns>
+    public JsonCommands JSON();
+
+    /// <summary>
+    /// Gets a command set for interacting with the RediSearch module.
+    /// </summary>
+    /// <param name="searchDialect">The search dialect version to use. Defaults to 2.</param>
+    /// <returns>Command set for search operations.</returns>
+    public SearchCommands FT(int? searchDialect = 2);
+
+    /// <summary>
+    /// Gets a command set for interacting with the Redis t-digest module.
+    /// </summary>
+    /// <returns>Command set for t-digest operations.</returns>
+    public TdigestCommands TDIGEST();
+
+    /// <summary>
+    /// Gets a command set for interacting with the RedisTimeSeries module.
+    /// </summary>
+    /// <returns>Command set for time series operations.</returns>
+    public TimeSeriesCommands TS();
+
+    /// <summary>
+    /// Gets a command set for interacting with the RedisBloom TopK module.
+    /// </summary>
+    /// <returns>Command set for TopK operations.</returns>
+    public TopKCommands TOPK();
+}

--- a/src/NRedisStack/RedisClient.cs
+++ b/src/NRedisStack/RedisClient.cs
@@ -7,11 +7,11 @@ namespace NRedisStack;
 /// Represents a Redis client that can connect to a Redis server 
 /// providing access to <see cref="IRedisDatabase"/> instances as well as the underlying multiplexer.
 /// </summary>
-public class RedisClient
+public class RedisClient: IRedisClient
 {
-    private ConnectionMultiplexer _multiplexer;
+    private IConnectionMultiplexer _multiplexer;
 
-    private RedisClient(ConnectionMultiplexer multiplexer)
+    private RedisClient(IConnectionMultiplexer multiplexer)
     {
         _multiplexer = multiplexer;
     }
@@ -21,7 +21,7 @@ public class RedisClient
     /// </summary>
     /// <param name="configuration">The string configuration to use for this client.</param>
     /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
-    public static async Task<RedisClient> ConnectAsync(string configuration, TextWriter? log = null) =>
+    public static async Task<IRedisClient> ConnectAsync(string configuration, TextWriter? log = null) =>
         await ConnectAsync(ConfigurationOptions.Parse(configuration), log);
 
     /// <summary>
@@ -30,7 +30,7 @@ public class RedisClient
     /// <param name="configuration">The string configuration to use for this client.</param>
     /// <param name="configure">Action to further modify the parsed configuration options.</param>
     /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
-    public static async Task<RedisClient> ConnectAsync(string configuration, Action<ConfigurationOptions> configure, TextWriter? log = null)
+    public static async Task<IRedisClient> ConnectAsync(string configuration, Action<ConfigurationOptions> configure, TextWriter? log = null)
     {
         Action<ConfigurationOptions> config = (ConfigurationOptions config) =>
         {
@@ -46,7 +46,7 @@ public class RedisClient
     /// <param name="configuration">The configuration options to use for this client.</param>
     /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
     /// <remarks>Note: For Sentinel, do <b>not</b> specify a <see cref="ConfigurationOptions.CommandMap"/> - this is handled automatically.</remarks>
-    public static async Task<RedisClient> ConnectAsync(ConfigurationOptions configuration, TextWriter? log = null)
+    public static async Task<IRedisClient> ConnectAsync(ConfigurationOptions configuration, TextWriter? log = null)
     {
         SetNames(configuration);
         return new RedisClient(await ConnectionMultiplexer.ConnectAsync(configuration, log));
@@ -55,9 +55,9 @@ public class RedisClient
     /// <summary>
     /// Creates a new <see cref="RedisClient"/> instance.
     /// </summary>
-    /// <param name="configuration">The string configuration to use for this client.</param>
+    /// <param name="configuration">The string configuration to use for this client. See the StackExchange.Redis configuration documentation(https://stackexchange.github.io/StackExchange.Redis/Configuration) for detailed information.</param>
     /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
-    public static RedisClient Connect(string configuration, TextWriter? log = null) =>
+    public static IRedisClient Connect(string configuration, TextWriter? log = null) =>
          Connect(ConfigurationOptions.Parse(configuration), log);
 
     /// <summary>
@@ -66,7 +66,7 @@ public class RedisClient
     /// <param name="configuration">The string configuration to use for this client.</param>
     /// <param name="configure">Action to further modify the parsed configuration options.</param>
     /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
-    public static RedisClient Connect(string configuration, Action<ConfigurationOptions> configure, TextWriter? log = null)
+    public static IRedisClient Connect(string configuration, Action<ConfigurationOptions> configure, TextWriter? log = null)
     {
         Action<ConfigurationOptions> config = (ConfigurationOptions config) =>
         {
@@ -82,7 +82,7 @@ public class RedisClient
     /// <param name="configuration">The configuration options to use for this client.</param>
     /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
     /// <remarks>Note: For Sentinel, do <b>not</b> specify a <see cref="ConfigurationOptions.CommandMap"/> - this is handled automatically.</remarks>
-    public static RedisClient Connect(ConfigurationOptions configuration, TextWriter? log = null)
+    public static IRedisClient Connect(ConfigurationOptions configuration, TextWriter? log = null)
     {
         SetNames(configuration);
         return new RedisClient(ConnectionMultiplexer.Connect(configuration, log));
@@ -104,7 +104,7 @@ public class RedisClient
     /// Gets the underlying <see cref="ConnectionMultiplexer"/> instance.
     /// </summary>
     /// <returns></returns>
-    public ConnectionMultiplexer GetMultiplexer()
+    public IConnectionMultiplexer GetMultiplexer()
     {
         return _multiplexer;
     }

--- a/src/NRedisStack/RedisClient.cs
+++ b/src/NRedisStack/RedisClient.cs
@@ -1,0 +1,127 @@
+using StackExchange.Redis;
+
+namespace NRedisStack;
+
+/// <summary>
+/// This class is EXPERIMENTAL!! and may change or removed in future releases.
+/// Represents a Redis client that can connect to a Redis server 
+/// providing access to <see cref="IRedisDatabase"/> instances as well as the underlying multiplexer.
+/// </summary>
+public class RedisClient
+{
+    private ConnectionMultiplexer _multiplexer;
+
+    private RedisClient(ConnectionMultiplexer multiplexer)
+    {
+        _multiplexer = multiplexer;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="RedisClient"/> instance.
+    /// </summary>
+    /// <param name="configuration">The string configuration to use for this client.</param>
+    /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
+    public static async Task<RedisClient> ConnectAsync(string configuration, TextWriter? log = null) =>
+        await ConnectAsync(ConfigurationOptions.Parse(configuration), log);
+
+    /// <summary>
+    /// Creates a new <see cref="RedisClient"/> instance.
+    /// </summary>
+    /// <param name="configuration">The string configuration to use for this client.</param>
+    /// <param name="configure">Action to further modify the parsed configuration options.</param>
+    /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
+    public static async Task<RedisClient> ConnectAsync(string configuration, Action<ConfigurationOptions> configure, TextWriter? log = null)
+    {
+        Action<ConfigurationOptions> config = (ConfigurationOptions config) =>
+        {
+            configure?.Invoke(config);
+            SetNames(config);
+        };
+        return new RedisClient(await ConnectionMultiplexer.ConnectAsync(configuration, configure, log));
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ConnectionMultiplexer"/> instance.
+    /// </summary>
+    /// <param name="configuration">The configuration options to use for this client.</param>
+    /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
+    /// <remarks>Note: For Sentinel, do <b>not</b> specify a <see cref="ConfigurationOptions.CommandMap"/> - this is handled automatically.</remarks>
+    public static async Task<RedisClient> ConnectAsync(ConfigurationOptions configuration, TextWriter? log = null)
+    {
+        SetNames(configuration);
+        return new RedisClient(await ConnectionMultiplexer.ConnectAsync(configuration, log));
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="RedisClient"/> instance.
+    /// </summary>
+    /// <param name="configuration">The string configuration to use for this client.</param>
+    /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
+    public static RedisClient Connect(string configuration, TextWriter? log = null) =>
+         Connect(ConfigurationOptions.Parse(configuration), log);
+
+    /// <summary>
+    /// Creates a new <see cref="RedisClient"/> instance.
+    /// </summary>
+    /// <param name="configuration">The string configuration to use for this client.</param>
+    /// <param name="configure">Action to further modify the parsed configuration options.</param>
+    /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
+    public static RedisClient Connect(string configuration, Action<ConfigurationOptions> configure, TextWriter? log = null)
+    {
+        Action<ConfigurationOptions> config = (ConfigurationOptions config) =>
+        {
+            configure?.Invoke(config);
+            SetNames(config);
+        };
+        return new RedisClient(ConnectionMultiplexer.Connect(configuration, configure, log));
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="RedisClient"/> instance.
+    /// </summary>
+    /// <param name="configuration">The configuration options to use for this client.</param>
+    /// <param name="log">The <see cref="TextWriter"/> to log to.</param>
+    /// <remarks>Note: For Sentinel, do <b>not</b> specify a <see cref="ConfigurationOptions.CommandMap"/> - this is handled automatically.</remarks>
+    public static RedisClient Connect(ConfigurationOptions configuration, TextWriter? log = null)
+    {
+        SetNames(configuration);
+        return new RedisClient(ConnectionMultiplexer.Connect(configuration, log));
+    }
+
+    /// <summary>
+    /// Gets a database instance.
+    /// </summary>
+    /// <param name="db">The ID to get a database for.</param>
+    /// <param name="asyncState">The async state to pass into the resulting <see cref="RedisDatabase"/>.</param>
+    /// <returns></returns>
+    public IRedisDatabase GetDatabase(int db = -1, object? asyncState = null)
+    {
+        var idatabase = _multiplexer.GetDatabase(db, asyncState);
+        return new RedisDatabase(idatabase);
+    }
+
+    /// <summary>
+    /// Gets the underlying <see cref="ConnectionMultiplexer"/> instance.
+    /// </summary>
+    /// <returns></returns>
+    public ConnectionMultiplexer GetMultiplexer()
+    {
+        return _multiplexer;
+    }
+
+    private static void SetNames(ConfigurationOptions config)
+    {
+        if (config.LibraryName == null)
+        {
+            config.LibraryName = Auxiliary.GetNRedisStackLibName();
+        }
+
+        if (config.ClientName == null)
+        {
+            config.ClientName = (Environment.MachineName ?? Environment.GetEnvironmentVariable("ComputerName") ?? "Unknown") + $"-NRedisStack(.NET_v{Environment.Version})";
+        }
+    }
+}
+
+
+

--- a/src/NRedisStack/RedisClient.cs
+++ b/src/NRedisStack/RedisClient.cs
@@ -7,7 +7,7 @@ namespace NRedisStack;
 /// Represents a Redis client that can connect to a Redis server 
 /// providing access to <see cref="IRedisDatabase"/> instances as well as the underlying multiplexer.
 /// </summary>
-public class RedisClient: IRedisClient
+public class RedisClient : IRedisClient
 {
     private IConnectionMultiplexer _multiplexer;
 

--- a/src/NRedisStack/RedisDatabase.cs
+++ b/src/NRedisStack/RedisDatabase.cs
@@ -1,0 +1,25 @@
+using NRedisStack.RedisStackCommands;
+using StackExchange.Redis;
+
+namespace NRedisStack;
+
+internal class RedisDatabase : DatabaseWrapper, IRedisDatabase
+{
+    public RedisDatabase(IDatabase db) : base(db) { }
+
+    public BloomCommands BF() => new BloomCommands(_db);
+
+    public CuckooCommands CF() => new CuckooCommands(_db);
+
+    public CmsCommands CMS() => new CmsCommands(_db);
+
+    public TopKCommands TOPK() => new TopKCommands(_db);
+
+    public TdigestCommands TDIGEST() => new TdigestCommands(_db);
+
+    public SearchCommands FT(int? searchDialect = 2) => new SearchCommands(_db, searchDialect);
+
+    public JsonCommands JSON() => new JsonCommands(_db);
+
+    public TimeSeriesCommands TS() => new TimeSeriesCommands(_db);
+}

--- a/tests/NRedisStack.Tests/ClientInfoTests.cs
+++ b/tests/NRedisStack.Tests/ClientInfoTests.cs
@@ -15,7 +15,8 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
     {
     }
 
-    [Fact]
+    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [InlineData] // No parameters passed, but still uses Theory
     public void TestMultiplexerInfoOnReconnect()
     {
         bool reconnected = false;
@@ -50,7 +51,8 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
         Assert.Contains("lib-name=SE.Redis", clientInfo);
     }
 
-    [Fact]
+    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [InlineData] // No parameters passed, but still uses Theory
     public void TestRedisClientInfoOnReconnect()
     {
         bool reconnected = false;
@@ -83,7 +85,8 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
         Assert.Contains("lib-name=NRedisStack", clientInfo);
     }
 
-    [Fact]
+    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [InlineData] // No parameters passed, but still uses Theory
     public void TestConnectionMultiplexerConnect()
     {
         IDatabase db = ConnectionMultiplexer.Connect(GetEndpoint()).GetDatabase();
@@ -93,7 +96,8 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
         Assert.Contains("lib-name=NRedisStack", db.Execute("CLIENT", "INFO").ToString());
     }
 
-    [Fact]
+    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [InlineData] // No parameters passed, but still uses Theory
     public void TestRedisClientConnect()
     {
         RedisClient rc = RedisClient.Connect(GetEndpoint());
@@ -102,7 +106,8 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
         Assert.Contains("lib-name=NRedisStack", db.Execute("CLIENT", "INFO").ToString());
     }
 
-    [Fact]
+    [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [InlineData] // No parameters passed, but still uses Theory
     public void TestRedisClientConnectWithConfigOptions()
     {
         ConfigurationOptions config = new ConfigurationOptions

--- a/tests/NRedisStack.Tests/ClientInfoTests.cs
+++ b/tests/NRedisStack.Tests/ClientInfoTests.cs
@@ -57,7 +57,7 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
     {
         bool reconnected = false;
         bool hang = false;
-        RedisClient rc = RedisClient.Connect(GetEndpoint());
+        IRedisClient rc = RedisClient.Connect(GetEndpoint());
         IRedisDatabase db = rc.GetDatabase();
         db.Multiplexer.ConnectionRestored += (sender, e) => reconnected = true;
 
@@ -100,7 +100,7 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
     [InlineData] // No parameters passed, but still uses Theory
     public void TestRedisClientConnect()
     {
-        RedisClient rc = RedisClient.Connect(GetEndpoint());
+        IRedisClient rc = RedisClient.Connect(GetEndpoint());
         IRedisDatabase db = rc.GetDatabase();
         db.StringSetAsync("key1", "something");
         Assert.Contains("lib-name=NRedisStack", db.Execute("CLIENT", "INFO").ToString());
@@ -116,7 +116,7 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
             LibraryName = "TestLib",
         };
 
-        RedisClient rc = RedisClient.Connect(config);
+        IRedisClient rc = RedisClient.Connect(config);
         IRedisDatabase db = rc.GetDatabase();
         db.StringSetAsync("key1", "something");
         Assert.Contains("lib-name=TestLib", db.Execute("CLIENT", "INFO").ToString());

--- a/tests/NRedisStack.Tests/ClientInfoTests.cs
+++ b/tests/NRedisStack.Tests/ClientInfoTests.cs
@@ -1,0 +1,133 @@
+using Xunit;
+using StackExchange.Redis;
+using NRedisStack.RedisStackCommands;
+using System.Text.Json;
+using NRedisStack.Search;
+using System.Diagnostics;
+using Microsoft.Identity.Client;
+using System.Net;
+
+namespace NRedisStack.Tests;
+
+public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
+{
+    public ClientInfoTests(EndpointsFixture endpointsFixture) : base(endpointsFixture)
+    {
+    }
+
+    [Fact]
+    public void TestMultiplexerInfoOnReconnect()
+    {
+        bool reconnected = false;
+        bool hang = false;
+        var db = GetCleanDatabase();
+        db.Multiplexer.ConnectionRestored += (sender, e) => reconnected = true;
+        Assert.Contains("lib-name=SE.Redis", db.Execute("CLIENT", "INFO").ToString());
+        db.FT()._List();
+        Assert.Contains("lib-name=NRedisStack", db.Execute("CLIENT", "INFO").ToString());
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        while ((!reconnected) && !hang)
+        {
+            try
+            {
+                RedisResult clientId = db.Execute("CLIENT", "ID");
+                db.ExecuteAsync("CLIENT", "KILL", "ID", ((RedisValue)clientId), "SKIPME", "NO");
+            }
+            catch (Exception) { }
+            hang = sw.Elapsed.TotalMilliseconds > 3000.0D;
+        }
+        Assert.True(reconnected, "Client was not reconnected");
+        Assert.False(hang, "It took more than 3 seconds, likely it hanged");
+        string clientInfo = null;
+        while (sw.Elapsed.Milliseconds < 4000 && clientInfo == null)
+        {
+            try { clientInfo = db.Execute("CLIENT", "INFO").ToString(); }
+            catch (Exception) { }
+        }
+        Assert.Contains("lib-name=SE.Redis", clientInfo);
+    }
+
+    [Fact]
+    public void TestRedisClientInfoOnReconnect()
+    {
+        bool reconnected = false;
+        bool hang = false;
+        RedisClient rc = RedisClient.Connect(GetEndpoint());
+        IRedisDatabase db = rc.GetDatabase();
+        db.Multiplexer.ConnectionRestored += (sender, e) => reconnected = true;
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        while ((!reconnected) && !hang)
+        {
+            try
+            {
+                RedisResult clientId = db.Execute("CLIENT", "ID");
+                db.ExecuteAsync("CLIENT", "KILL", "ID", ((RedisValue)clientId), "SKIPME", "NO");
+            }
+            catch (Exception) { }
+            hang = sw.Elapsed.TotalMilliseconds > 3000.0D;
+        }
+
+        Assert.True(reconnected, "Client was not reconnected");
+        Assert.False(hang, "It took more than 3 seconds, likely it hanged");
+        string clientInfo = null;
+        while (sw.Elapsed.Milliseconds < 4000 && clientInfo == null)
+        {
+            try { clientInfo = db.Execute("CLIENT", "INFO").ToString(); }
+            catch (Exception) { }
+        }
+        Assert.Contains("lib-name=NRedisStack", clientInfo);
+    }
+
+    [Fact]
+    public void TestConnectionMultiplexerConnect()
+    {
+        IDatabase db = ConnectionMultiplexer.Connect(GetEndpoint()).GetDatabase();
+        Auxiliary.ResetInfoDefaults();
+        db.StringSetAsync("key1", "something");
+        var _ = db.FT()._List();
+        Assert.Contains("lib-name=NRedisStack", db.Execute("CLIENT", "INFO").ToString());
+    }
+
+    [Fact]
+    public void TestRedisClientConnect()
+    {
+        RedisClient rc = RedisClient.Connect(GetEndpoint());
+        IRedisDatabase db = rc.GetDatabase();
+        db.StringSetAsync("key1", "something");
+        Assert.Contains("lib-name=NRedisStack", db.Execute("CLIENT", "INFO").ToString());
+    }
+
+    [Fact]
+    public void TestRedisClientConnectWithConfigOptions()
+    {
+        ConfigurationOptions config = new ConfigurationOptions
+        {
+            EndPoints = { GetEndpoint() },
+            LibraryName = "TestLib",
+        };
+
+        RedisClient rc = RedisClient.Connect(config);
+        IRedisDatabase db = rc.GetDatabase();
+        db.StringSetAsync("key1", "something");
+        Assert.Contains("lib-name=TestLib", db.Execute("CLIENT", "INFO").ToString());
+    }
+
+    private string GetEndpoint()
+    {
+        var ep = GetCleanDatabase().Multiplexer.GetEndPoints()[0];
+        String endpoint = null;
+        if (ep is IPEndPoint iep)
+        {
+            endpoint = $"{iep.Address}:{iep.Port}";
+        }
+        else if (ep is DnsEndPoint dep)
+        {
+            endpoint = $"{dep.Host}:{dep.Port}";
+        }
+        return endpoint;
+    }
+}

--- a/tests/NRedisStack.Tests/ClientInfoTests.cs
+++ b/tests/NRedisStack.Tests/ClientInfoTests.cs
@@ -23,6 +23,7 @@ public class ClientInfoTests : AbstractNRedisStackTest, IDisposable
         var db = GetCleanDatabase();
         db.Multiplexer.ConnectionRestored += (sender, e) => reconnected = true;
         Assert.Contains("lib-name=SE.Redis", db.Execute("CLIENT", "INFO").ToString());
+        Auxiliary.ResetInfoDefaults();
         db.FT()._List();
         Assert.Contains("lib-name=NRedisStack", db.Execute("CLIENT", "INFO").ToString());
 

--- a/tests/NRedisStack.Tests/Core Commands/CoreTests.cs
+++ b/tests/NRedisStack.Tests/Core Commands/CoreTests.cs
@@ -51,7 +51,7 @@ public class CoreTests : AbstractNRedisStackTest, IDisposable
         db.Execute(new SerializedCommand("PING")); // only the extension method of Execute (which is used for all the commands of Redis Stack) will set the library name and version.
 
         var info = db.Execute("CLIENT", "INFO").ToString();
-        Assert.Contains($"lib-name=NRedisStack(.NET_v{Environment.Version}) lib-ver={GetNRedisStackVersion()}", info);
+        Assert.Contains($"lib-name=NRedisStack-{GetNRedisStackVersion()} lib-ver={GetNRedisStackVersion()}", info);
     }
 
     [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.1.242")]
@@ -64,7 +64,7 @@ public class CoreTests : AbstractNRedisStackTest, IDisposable
         await db.ExecuteAsync(new SerializedCommand("PING")); // only the extension method of Execute (which is used for all the commands of Redis Stack) will set the library name and version.
 
         var info = (await db.ExecuteAsync("CLIENT", "INFO")).ToString();
-        Assert.Contains($"lib-name=NRedisStack(.NET_v{Environment.Version}) lib-ver={GetNRedisStackVersion()}", info);
+        Assert.Contains($"lib-name=NRedisStack-{GetNRedisStackVersion()} lib-ver={GetNRedisStackVersion()}", info);
     }
 
     [SkipIfRedis(Is.Enterprise, Comparison.LessThan, "7.1.242")]


### PR DESCRIPTION
Closes/Fixes #406 

Current implementation for setting client lib info on connections is only working for single initial connection in the application context/runtime, which leaves the cases and setups given below out of scope;
- client reconnects
- pubsub subscription connections in RESP2 mode
- cluster setup

There are couple of ways to improve the situation with setting library info on connections but all have its downsides. Here some of them with their own drawbacks;
- using connections events 
	- this doesnt provide a way to set subscription connections
	- need to manage event registration process for each and every connections explicitly, which is kind of unnecessary burden both in terms of performance and maintenance
- renaming/overriding internals with unnatural/unreliable ways 
	- this is risky to play with internals of other library
	- this means introducing a sophisticated code/solution for a simple problem, which would make it 
	- this is a potential maintenance issue due to relying on unexposed API/parts of StackExchange.Redis assembly.
- providing a high-level client initializer wrapping both database and multiplexer instances
	- this changes the initial point of contact of developer with the library API and change how the developer experiences
	- it brings maintenance work when the underlying API changes with IDatabase interface, this was handled in a zero-effort manner with help of extension methods previously


I choose to follow the third approach since it is clear, reliable and simplistic implementation compared to other two.
In this PR there are three major types introduced, two of them is exposed in public API;
**IRedisDatabase** : An interface to allow access to modules commands in addition to those in IDatabase 
**RedisClient** : Provides creation+configuration of IRedisDatabase instances
**DatabaseWrapper** : Underlying wrapper class to compose IDatabase and modules commands into same type.

Existing implementation with extension methods will stay (at least until a major release) and we will keep these new types as experimental, until we make sure this approach brings more benefits, allow  required modifications with underlying types and complies with up-coming changes with StackExchange.Redis.