### PR TITLE
Add support for VANAMA index algorithm at index creation

### DIFF
--- a/src/NRedisStack/Search/FieldName.cs
+++ b/src/NRedisStack/Search/FieldName.cs
@@ -36,5 +36,7 @@ namespace NRedisStack.Search
             this.Alias = attribute;
             return this;
         }
+
+        public static implicit operator FieldName(string name) => Of(name);
     }
 }

--- a/src/NRedisStack/Search/Schema.cs
+++ b/src/NRedisStack/Search/Schema.cs
@@ -1,4 +1,5 @@
-﻿using NRedisStack.Search.Literals;
+﻿using System.Diagnostics;
+using NRedisStack.Search.Literals;
 using static NRedisStack.Search.Schema.GeoShapeField;
 using static NRedisStack.Search.Schema.VectorField;
 
@@ -260,10 +261,12 @@ namespace NRedisStack.Search
             public enum VectorAlgo
             {
                 FLAT,
-                HNSW
+                HNSW,
+                SVS_VAMANA,
             }
 
             public VectorAlgo Algorithm { get; }
+
             public Dictionary<string, object>? Attributes { get; }
             public bool MissingIndex { get; }
 
@@ -275,25 +278,340 @@ namespace NRedisStack.Search
                 MissingIndex = missingIndex;
             }
 
+            internal VectorField(FieldName name, VectorAlgo algorithm,
+                VectorType type, int dimensions, VectorDistanceMetric distanceMetric,
+                Dictionary<string, object>? attributes, bool missingIndex)
+                : this(name, algorithm, attributes, missingIndex)
+            {
+                Type = type;
+                Dimensions = dimensions;
+                DistanceMetric = distanceMetric;
+            }
+
             public VectorField(string name, VectorAlgo algorithm, Dictionary<string, object>? attributes = null, bool missingIndex = false)
                                : this(FieldName.Of(name), algorithm, attributes, missingIndex) { }
 
             internal override void AddFieldTypeArgs(List<object> args)
             {
-                args.Add(Algorithm.ToString());
-                if (Attributes != null)
+                args.Add(Algorithm switch
                 {
-                    args.Add(Attributes.Count() * 2);
-
-                    foreach (var attribute in Attributes)
+                    VectorAlgo.FLAT => "FLAT",
+                    VectorAlgo.HNSW => "HNSW",
+                    VectorAlgo.SVS_VAMANA => "SVS-VAMANA",
+                    _ => Algorithm.ToString(), // fallback
+                });
+                var attribs = Attributes;
+                var count = DirectAttributeCount + (attribs?.Count ?? 0);
+                args.Add(count * 2);
+#if DEBUG
+                int before = args.Count;
+#endif
+                AddDirectAttributes(args);
+                if (attribs != null)
+                {
+                    foreach (var attribute in attribs)
                     {
                         args.Add(attribute.Key);
                         args.Add(attribute.Value);
                     }
                 }
+#if DEBUG
+                Debug.Assert(args.Count == (before + (count * 2)), "Arg count mismatch; check " + nameof(AddDirectAttributes) + " vs " + nameof(DirectAttributeCount));
+#endif
                 if (MissingIndex) args.Add(FieldOptions.INDEXMISSING);
             }
+
+            // attributes handled inside the type-system (rather than via Attributes)
+
+            /// <summary>
+            /// The width, or number of dimensions, of the vector embeddings stored in this field. In other words, the number of floating point elements comprising the vector. DIM must be a positive integer. The vector used to query this field must have the exact dimensions as the field itself.
+            /// </summary>
+            public int Dimensions { get; set; } = 0;
+            public new VectorType Type { get; set; } = VectorType.NotSpecified;
+            public VectorDistanceMetric DistanceMetric { get; set; } = VectorDistanceMetric.NotSpecified;
+
+            internal virtual int DirectAttributeCount
+                => (Dimensions == 0 ? 0 : 1)
+                + (Type == VectorType.NotSpecified ? 0 : 1)
+                + (DistanceMetric == VectorDistanceMetric.NotSpecified ? 0 : 1);
+
+            internal virtual void AddDirectAttributes(List<object> args)
+            {
+                if (Dimensions != 0)
+                {
+                    args.Add("DIM");
+                    args.Add(Dimensions);
+                }
+                if (Type != VectorType.NotSpecified)
+                {
+                    args.Add("TYPE");
+                    args.Add(Type switch
+                    {
+                        VectorType.FLOAT32 => "FLOAT32",
+                        VectorType.FLOAT64 => "FLOAT64",
+                        VectorType.BFLOAT16 => "BFLOAT16",
+                        VectorType.FLOAT16 => "FLOAT16",
+                        _ => Type.ToString(), // fallback
+                    });
+                }
+
+                if (DistanceMetric != VectorDistanceMetric.NotSpecified)
+                {
+                    args.Add("DISTANCE_METRIC");
+                    args.Add(DistanceMetric switch
+                    {
+                        VectorDistanceMetric.EuclideanDistance => "L2",
+                        VectorDistanceMetric.InnerProduct => "IP",
+                        VectorDistanceMetric.CosineDistance => "COSINE",
+                        _ => DistanceMetric.ToString(), // fallback
+                    });
+                }
+            }
+
+            /// <summary>
+            /// The storage type for a vector field.
+            /// </summary>
+            public enum VectorType
+            {
+                /// <summary>
+                /// Not specified, or specified via <see cref="VectorField.Attributes"/>.
+                /// </summary>
+                NotSpecified = 0,
+                /// <summary>
+                /// 32-bit floating point.
+                /// </summary>
+                FLOAT32 = 1,
+                /// <summary>
+                /// 64-bit floating point.
+                /// </summary>
+                FLOAT64 = 2,
+                /// <summary>
+                /// 16-bit "brain" floating point
+                /// </summary>
+                BFLOAT16 = 3, // requires v2.10 or later.
+                /// <summary>
+                /// 16-bit floating point.
+                /// </summary>
+                FLOAT16 = 4, // requires v2.10 or later.
+            }
+
+            /// <summary>
+            /// The distance metric to use for vector similarity search.
+            /// </summary>
+            public enum VectorDistanceMetric
+            {
+                /// <summary>
+                /// Not specified, or specified via <see cref="VectorField.Attributes"/>.
+                /// </summary>
+                NotSpecified = 0,
+                /// <summary>
+                /// Euclidean distance between two vectors.
+                /// </summary>
+                EuclideanDistance = 1,
+                /// <summary>
+                /// Inner product of two vectors.
+                /// </summary>
+                InnerProduct = 2,
+                /// <summary>
+                /// Cosine distance of two vectors.
+                /// </summary>
+                CosineDistance = 3,
+            }
+
+            /// <summary>
+            /// The distance metric to use for vector similarity search.
+            /// </summary>
+            public enum VectorCompressionAlgorithm
+            {
+                /// <summary>
+                /// Not specified, or specified via <see cref="VectorField.Attributes"/>.
+                /// </summary>
+                NotSpecified = 0,
+                LVQ8 = 1,
+                LVQ4 = 2,
+                LVQ4x4 = 3,
+                LVQ4x8 = 4,
+                LeanVec4x8 = 5,
+                LeanVec8x8 = 6,
+            }
         }
+
+
+        /// <summary>
+        /// A <see cref="VectorField"/> that uses the <see cref="VectorAlgo.FLAT"/> algorithm.
+        /// </summary>
+        public class FlatVectorField : VectorField
+        {
+            public FlatVectorField(FieldName name,
+                VectorType type, int dimensions, VectorDistanceMetric distanceMetric,
+                Dictionary<string, object>? attributes = null, bool missingIndex = false)
+                : base(name, VectorAlgo.FLAT, type, dimensions, distanceMetric, attributes, missingIndex)
+            {
+            }
+        }
+
+        /// <summary>
+        /// A <see cref="VectorField"/> that uses the <see cref="VectorAlgo.Hnsw"/> algorithm.
+        /// </summary>
+        public class HnswVectorField : VectorField
+        {
+            public HnswVectorField(FieldName name,
+                VectorType type, int dimensions, VectorDistanceMetric distanceMetric,
+                Dictionary<string, object>? attributes = null, bool missingIndex = false)
+                : base(name, VectorAlgo.HNSW, type, dimensions, distanceMetric, attributes, missingIndex)
+            {
+            }
+
+            // optional attributes
+            /// <summary>
+            /// "M"; Max number of outgoing edges (connections) for each node in a graph layer. On layer zero, the max number of connections will be 2 * M. Higher values increase accuracy, but also increase memory usage and index build time. The default is 16.
+            /// </summary>
+            public int MaxOutgoingConnections { get; set; } = DEFAULT_M;
+
+            /// <summary>
+            /// "EF_CONSTRUCTION"; Max number of connected neighbors to consider during graph building. Higher values increase accuracy, but also increase index build time. The default is 200.
+            /// </summary>
+            public int MaxConnectedNeighbors { get; set; } = DEFAULT_EF_CONSTRUCTION;
+
+            /// <summary>
+            /// "EF_RUNTIME"; Max top candidates during KNN search. Higher values increase accuracy, but also increase search latency. The default is 10.
+            /// </summary>
+            public int MaxTopCandidates { get; set; } = DEFAULT_EF_RUNTIME;
+
+            /// <summary>
+            /// "EPSILON"; Relative factor that sets the boundaries in which a range query may search for candidates. That is, vector candidates whose distance from the query vector is radius * (1 + EPSILON) are potentially scanned, allowing more extensive search and more accurate results, at the expense of run time. The default is 0.01.
+            /// </summary>
+            public double BoundaryFactor { get; set; } = DEFAULT_EPSILON;
+
+            internal const int DEFAULT_M = 16, DEFAULT_EF_CONSTRUCTION = 200, DEFAULT_EF_RUNTIME = 10;
+            internal const double DEFAULT_EPSILON = 0.01;
+            internal override int DirectAttributeCount
+                => base.DirectAttributeCount
+                   + (MaxOutgoingConnections == DEFAULT_M ? 0 : 1)
+                   + (MaxConnectedNeighbors == DEFAULT_EF_CONSTRUCTION ? 0 : 1)
+                   + (MaxTopCandidates == DEFAULT_EF_RUNTIME ? 0 : 1)
+                   // ReSharper disable once CompareOfFloatsByEqualityOperator
+                   + (BoundaryFactor == DEFAULT_EPSILON ? 0 : 1);
+
+            internal override void AddDirectAttributes(List<object> args)
+            {
+                base.AddDirectAttributes(args);
+                if (MaxOutgoingConnections != DEFAULT_M)
+                {
+                    args.Add("M");
+                    args.Add(MaxOutgoingConnections);
+                }
+                if (MaxConnectedNeighbors != DEFAULT_EF_CONSTRUCTION)
+                {
+                    args.Add("EF_CONSTRUCTION");
+                    args.Add(MaxConnectedNeighbors);
+                }
+                if (MaxTopCandidates != DEFAULT_EF_RUNTIME)
+                {
+                    args.Add("EF_RUNTIME");
+                    args.Add(MaxTopCandidates);
+                }
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (BoundaryFactor != DEFAULT_EPSILON)
+                {
+                    args.Add("EPSILON");
+                    args.Add(BoundaryFactor);
+                }
+            }
+        }
+
+        /// <summary>
+        /// A <see cref="VectorField"/> that uses the <see cref="VectorAlgo.SVS_VAMANA"/> algorithm.
+        /// </summary>
+        public class SvsVanamaVectorField : VectorField
+        {
+            public SvsVanamaVectorField(FieldName name,
+                VectorType type, int dimensions, VectorDistanceMetric distanceMetric,
+                Dictionary<string, object>? attributes = null, bool missingIndex = false)
+                : base(name, VectorAlgo.SVS_VAMANA, type, dimensions, distanceMetric, attributes, missingIndex)
+            {
+            }
+
+            public VectorCompressionAlgorithm CompressionAlgorithm { get; set; } = VectorCompressionAlgorithm.NotSpecified;
+
+            internal override int DirectAttributeCount
+                => (CompressionAlgorithm == VectorCompressionAlgorithm.NotSpecified ? 0 : 1)
+                   + base.DirectAttributeCount
+                   + (ConstructionWindowSize == DEFAULT_CONSTRUCTION_WINDOW_SIZE ? 0 : 1)
+                   + (GraphMaxDegree == DEFAULT_GRAPH_MAX_DEGREE ? 0 : 1)
+                   + (SearchWindowSize == DEFAULT_SEARCH_WINDOW_SIZE ? 0 : 1)
+                   // ReSharper disable once CompareOfFloatsByEqualityOperator
+                   + (RangeSearchApproximationFactor == DEFAULT_EPSILON ? 0 : 1)
+                   + (TrainingThreshold == 0 ? 0 : 1)
+                   + (ReducedDimensions == 0 ? 0 : 1);
+
+            internal override void AddDirectAttributes(List<object> args)
+            {
+                if (CompressionAlgorithm != VectorCompressionAlgorithm.NotSpecified)
+                {
+                    args.Add("COMPRESSION");
+                    args.Add(CompressionAlgorithm switch
+                    {
+                        VectorCompressionAlgorithm.LVQ8 => "LVQ8",
+                        VectorCompressionAlgorithm.LVQ4 => "LVQ4",
+                        VectorCompressionAlgorithm.LVQ4x4 => "LVQ4x4",
+                        VectorCompressionAlgorithm.LVQ4x8 => "LVQ4x8",
+                        VectorCompressionAlgorithm.LeanVec4x8 => "LEAN_VEC4x8",
+                        VectorCompressionAlgorithm.LeanVec8x8 => "LEAN_VEC8x8",
+                        _ => CompressionAlgorithm.ToString(), // fallback
+                    });
+                }
+                base.AddDirectAttributes(args);
+                if (ConstructionWindowSize != DEFAULT_CONSTRUCTION_WINDOW_SIZE)
+                {
+                    args.Add("CONSTRUCTION_WINDOW_SIZE");
+                    args.Add(ConstructionWindowSize);
+                }
+                if (GraphMaxDegree != DEFAULT_GRAPH_MAX_DEGREE)
+                {
+                    args.Add("GRAPH_MAX_DEGREE");
+                    args.Add(GraphMaxDegree);
+                }
+                if (SearchWindowSize != DEFAULT_SEARCH_WINDOW_SIZE)
+                {
+                    args.Add("SEARCH_WINDOW_SIZE");
+                    args.Add(SearchWindowSize);
+                }
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (RangeSearchApproximationFactor != DEFAULT_EPSILON)
+                {
+                    args.Add("EPSILON");
+                    args.Add(RangeSearchApproximationFactor);
+                }
+                if (TrainingThreshold != 0)
+                {
+                    args.Add("TRAINING_THRESHOLD");
+                    args.Add(TrainingThreshold);
+                }
+                if (ReducedDimensions != 0)
+                {
+                    args.Add("REDUCE");
+                    args.Add(ReducedDimensions);
+                }
+            }
+
+            public int ConstructionWindowSize { get; set; } = DEFAULT_CONSTRUCTION_WINDOW_SIZE;
+            public int GraphMaxDegree { get; set; } = DEFAULT_GRAPH_MAX_DEGREE;
+            public int SearchWindowSize { get; set; } = DEFAULT_SEARCH_WINDOW_SIZE;
+            public double RangeSearchApproximationFactor { get; set; } = DEFAULT_EPSILON;
+            /// <summary>
+            /// Number of vectors after which training is triggered; defaults to 10 * DEFAULT_BLOCK_SIZE (or the provided value, limited to 100 * DEFAULT_BLOCK_SIZE) where DEFAULT_BLOCK_SIZE = 1024
+            /// </summary>
+            public int TrainingThreshold { get; set; }
+            /// <summary>
+            /// The dimension used when using LeanVec compression for dimensionality reduction; defaults to dim/2 (applicable only with compression of type LeanVec, should always be < dim)
+            /// </summary>
+            public int ReducedDimensions { get; set; }
+
+            internal const int DEFAULT_CONSTRUCTION_WINDOW_SIZE = 200,  DEFAULT_GRAPH_MAX_DEGREE = 32,  DEFAULT_SEARCH_WINDOW_SIZE = 10;
+            internal const double DEFAULT_EPSILON = 0.01;
+        }
+
         public List<Field> Fields { get; } = new List<Field>();
 
         /// <summary>
@@ -526,6 +844,61 @@ namespace NRedisStack.Search
         public Schema AddVectorField(string name, VectorAlgo algorithm, Dictionary<string, object>? attributes = null, bool missingIndex = false)
         {
             Fields.Add(new VectorField(name, algorithm, attributes, missingIndex));
+            return this;
+        }
+
+        /// <summary>
+        /// Add a <see href="VectorAlgo.FLAT"/> vector to the schema.
+        /// </summary>
+        public Schema AddFlatVectorField(FieldName name, VectorType type, int dimensions, VectorDistanceMetric distanceMetric, Dictionary<string, object>? attributes = null, bool missingIndex = false)
+        {
+            Fields.Add(new FlatVectorField(name, type, dimensions, distanceMetric, attributes, missingIndex));
+            return this;
+        }
+
+        /// <summary>
+        /// Add a <see href="VectorAlgo.HNSW"/> vector to the schema.
+        /// </summary>
+        public Schema AddHnswVectorField(FieldName name, VectorType type, int dimensions, VectorDistanceMetric distanceMetric,
+            int maxOutgoingConnections = HnswVectorField.DEFAULT_M,
+            int maxConnectedNeighbors = HnswVectorField.DEFAULT_EF_CONSTRUCTION,
+            int maxTopCandidates = HnswVectorField.DEFAULT_EF_RUNTIME,
+            double boundaryFactor = HnswVectorField.DEFAULT_EPSILON,
+            Dictionary<string, object>? attributes = null, bool missingIndex = false)
+        {
+            Fields.Add(new HnswVectorField(name, type, dimensions, distanceMetric, attributes, missingIndex)
+            {
+                MaxOutgoingConnections = maxOutgoingConnections,
+                MaxConnectedNeighbors = maxConnectedNeighbors,
+                MaxTopCandidates = maxTopCandidates,
+                BoundaryFactor = boundaryFactor,
+            });
+            return this;
+        }
+
+        /// <summary>
+        /// Add a <see href="VectorAlgo.SVS_VAMANA"/> vector to the schema.
+        /// </summary>
+        public Schema AddSvsVanamaVectorField(FieldName name, VectorType type, int dimensions, VectorDistanceMetric distanceMetric,
+            VectorCompressionAlgorithm compressionAlgorithm = VectorCompressionAlgorithm.NotSpecified,
+            int constructionWindowSize = SvsVanamaVectorField.DEFAULT_CONSTRUCTION_WINDOW_SIZE,
+            int graphMaxDegree = SvsVanamaVectorField.DEFAULT_GRAPH_MAX_DEGREE,
+            int searchWindowSize = SvsVanamaVectorField.DEFAULT_SEARCH_WINDOW_SIZE,
+            double rangeSearchApproximationFactor = SvsVanamaVectorField.DEFAULT_EPSILON,
+            int trainingThreshold = 0,
+            int reducedDimensions = 0,
+            Dictionary<string, object>? attributes = null, bool missingIndex = false)
+        {
+            Fields.Add(new SvsVanamaVectorField(name, type, dimensions, distanceMetric, attributes, missingIndex)
+            {
+                CompressionAlgorithm = compressionAlgorithm,
+                ConstructionWindowSize = constructionWindowSize,
+                GraphMaxDegree = graphMaxDegree,
+                SearchWindowSize = searchWindowSize,
+                RangeSearchApproximationFactor = rangeSearchApproximationFactor,
+                TrainingThreshold = trainingThreshold,
+                ReducedDimensions = reducedDimensions,
+            });
             return this;
         }
     }

--- a/src/NRedisStack/SerializedCommand.cs
+++ b/src/NRedisStack/SerializedCommand.cs
@@ -16,5 +16,10 @@ namespace NRedisStack.RedisStackCommands
             Command = command;
             Args = args.ToArray();
         }
+
+        /// <inheritdoc />
+        public override string ToString() => Args is { Length: > 0 }
+            ? (Command + " " + string.Join(" ", Args))
+            : Command;
     }
 }


### PR DESCRIPTION
Note: the existing API *only* used `Dictionary<string, object> attributes`, which means that *we could* just add the enum addition and call it a day, and let the user worry about making everything work. However, it seems sensible to help the user out by providing an extended API with proper support for the options specific to each type, so:

- add structured object-model for complex vector index creation, with specialized types for the 3 vector types
  - add VectorField.Dimensions, .Type and .DistanceMetric
  - add mechanism to bake those into command without breaking existing usage
    - AddDirectAttributes, DirectAttributeCount
  - new type FlatVectorField
  - new type HnswVectorField
  - new type SvsVanamaVectorField
- make it possible to extract approx command from SerializedCommand.ToString()
- add implicit operator from string to FieldName to reduce new overloads needed
- add new Schema.Add*VectorField APIs
- add tests to demonstrate correct index construction