### PR TITLE
CI: install SDK 9

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -24,11 +24,13 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-
-    - name: Install .NET Core 
+    
+    - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{inputs.dotnet-version}}
+        dotnet-version: |
+          '9.0.x'
+          ${{inputs.dotnet-version}}
         dotnet-quality: 'ga'
 
     - name: Setup Environment variables and run Redis

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -29,7 +29,7 @@ runs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          '9.0.x'
+          9.0.x
           ${{inputs.dotnet-version}}
         dotnet-quality: 'ga'
 


### PR DESCRIPTION
Intent: use modern C# in the code, even when targeting down-level test TFMs

To do this, we install the current .NET SDK (9 at time of writing) alongside the test target, so the build and run both work appropriately.

This multi-target approach is cited in the official docs, [here](https://github.com/actions/setup-dotnet?tab=readme-ov-file#usage)