### PR TITLE
PackageLicenseExpression, PackageProjectUrl .csproj addition

### DIFF
--- a/src/NRedisStack/NRedisStack.csproj
+++ b/src/NRedisStack/NRedisStack.csproj
@@ -1,25 +1,27 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-	<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
-	<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<LangVersion>latest</LangVersion>
-	<ImplicitUsings>enable</ImplicitUsings>
-	<Authors>Redis Open Source</Authors>
-	<Owners>Redis OSS</Owners>
-	<Description>.Net Client for Redis Stack</Description>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<Version>1.0.0-beta1</Version>
-	<ReleaseVersion>1.0.0-beta1</ReleaseVersion>
-	<PackageVersion>1.0.0-beta1</PackageVersion>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Authors>Redis Open Source</Authors>
+    <Owners>Redis OSS</Owners>
+    <Description>.Net Client for Redis Stack</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Version>1.0.0-beta1</Version>
+    <ReleaseVersion>1.0.0-beta1</ReleaseVersion>
+    <PackageVersion>1.0.0-beta1</PackageVersion>
+    <PackageProjectUrl>https://github.com/redis/NRedisStack</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="NetTopologySuite" Version="2.5.0" />
-	<PackageReference Include="System.Text.Json" Version="9.0.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-	<PackageReference Include="StackExchange.Redis" Version="2.8.24" />
-	<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="NetTopologySuite" Version="2.5.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
My company's code analysis security software ([Aikido](https://www.aikido.dev/)) complains that the licensing for the NRedisStack nuget package is unclear.  To help my company and other companies like us resolve the citation, I kindly request/suggest the project's MIT license be set in the NuGet package properties via a PackageLicenseExpression tag as so.  I added the PackageProjectUrl as well, while I was at it, to help quickly link developers to the repo from the NuGet package explorer in Visual Studio.

When I opened the .csproj file, it was a mix of tabs and spaces, and I wasn't sure which convention was preferable. I saw vague indication spaces were the precedent, so I rationalized the existing tabs into spaces and indented the tags accordingly. Note that most VS installations use tabs for .csproj files by default, so that might be why/how tabs ended up being added. Surely let me know if tabs are preferred instead, and/or if I should go about resolving this citation in general another way.  Thanks!