### PR TITLE
Remove a redundant wait-loop in the tests

### DIFF
--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -55,20 +55,12 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
     private void AssertDatabaseSize(IDatabase db, int expected)
     {
-        // in part, this is to allow replication to catch up
-        for (int i = 0; i < 10; i++)
-        {
-            Assert.Equal(expected, DatabaseSize(db));
-        }
+        Assert.Equal(expected, DatabaseSize(db));
     }
 
     private async Task AssertDatabaseSizeAsync(IDatabase db, int expected)
     {
-        // in part, this is to allow replication to catch up
-        for (int i = 0; i < 10; i++)
-        {
-            Assert.Equal(expected, await DatabaseSizeAsync(db));
-        }
+        Assert.Equal(expected, await DatabaseSizeAsync(db));
     }
 
     [SkipIfRedisTheory(Is.Enterprise)]


### PR DESCRIPTION
Loop in `AssertDatabaseSize[Async` - this was *intended* to allow replication catch-up, but the real problem was cluster + FT.* on pre-v8 servers, which is not a supported scenario. Tests are stable without this.