### PR TITLE
8.8 (unstable) validation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
         max-parallel: 15
         fail-fast: false
         matrix:
-          redis-version: [ '8.6', '8.4', '8.2', '7.4', '7.2', '6.2']
+          redis-version: [ '8.8', '8.6', '8.4', '8.2', '7.4', '7.2', '6.2']
           dotnet-version: ['8.0', '9.0', '10.0']
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true

--- a/tests/NRedisStack.Tests/CommunityEditionUpdatesTests.cs
+++ b/tests/NRedisStack.Tests/CommunityEditionUpdatesTests.cs
@@ -103,7 +103,9 @@ public class CommunityEditionUpdatesTests : AbstractNRedisStackTest, IDisposable
         IServer server = getAnyPrimary(muxer);
 
         var searchInfo = server.Info("search");
-        CustomAssertions.GreaterThan(searchInfo.Length, 8);
+        // v8.8 reduces a lot of noise around "info search" output
+        var expectCount = EndpointsFixture.IsAtLeast(8, 8) ? 3 : 8;
+        CustomAssertions.GreaterThan(searchInfo.Length, expectCount);
     }
 
 }

--- a/tests/NRedisStack.Tests/CommunityEditionUpdatesTests.cs
+++ b/tests/NRedisStack.Tests/CommunityEditionUpdatesTests.cs
@@ -104,7 +104,7 @@ public class CommunityEditionUpdatesTests : AbstractNRedisStackTest, IDisposable
 
         var searchInfo = server.Info("search");
         // v8.8 reduces a lot of noise around "info search" output
-        var expectCount = EndpointsFixture.IsAtLeast(8, 8) ? 3 : 8;
+        var expectCount = EndpointsFixture.IsAtLeast(8, 8) ? 2 : 8;
         CustomAssertions.GreaterThan(searchInfo.Length, expectCount);
     }
 

--- a/tests/NRedisStack.Tests/EndpointsFixture.cs
+++ b/tests/NRedisStack.Tests/EndpointsFixture.cs
@@ -67,6 +67,24 @@ public class EndpointsFixture : IDisposable
 
     public static Version RedisVersion = new(Environment.GetEnvironmentVariable("REDIS_VERSION") ?? "0.0.0");
 
+    public static bool IsAtLeast(int major, int minor = 0, int build = 0, int revision = 0)
+    {
+        var version = RedisVersion;
+        if (version.Major > major) return true;
+        if (version.Major < major) return false;
+
+        // if here, we're a match on major; test minor
+        if (version.Minor > minor) return true;
+        if (version.Minor < minor) return false;
+
+        // if here, we're a match on minor; test build
+        if (version.Build > build) return true;
+        if (version.Build < build) return false;
+
+        // if here, we're a match on build; test revision
+        return version.Revision >= revision;
+    }
+
     public EndpointsFixture()
     {
         if (redisEndpointsPath != null && File.Exists(redisEndpointsPath))

--- a/tests/NRedisStack.Tests/EndpointsFixture.cs
+++ b/tests/NRedisStack.Tests/EndpointsFixture.cs
@@ -70,19 +70,24 @@ public class EndpointsFixture : IDisposable
     public static bool IsAtLeast(int major, int minor = 0, int build = 0, int revision = 0)
     {
         var version = RedisVersion;
-        if (version.Major > major) return true;
-        if (version.Major < major) return false;
+        // note: watch out for negative numbers (means "undefined") from parsing n-part strings 
+        var test = Math.Max(version.Major, 0);
+        if (test > major) return true;
+        if (test < major) return false;
 
         // if here, we're a match on major; test minor
-        if (version.Minor > minor) return true;
-        if (version.Minor < minor) return false;
+        test = Math.Max(version.Minor, 0); // interpret "9" as "9.0"
+        if (test > minor) return true;
+        if (test < minor) return false;
 
         // if here, we're a match on minor; test build
-        if (version.Build > build) return true;
-        if (version.Build < build) return false;
+        test = Math.Max(version.Build, 0); // interpret "9.0" as "9.0.0"
+        if (test > build) return true;
+        if (test < build) return false;
 
         // if here, we're a match on build; test revision
-        return version.Revision >= revision;
+        test = Math.Max(version.Revision, 0); // interpret "9.0.0" as "9.0.0.0"
+        return test >= revision;
     }
 
     public EndpointsFixture()

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -31,6 +31,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
         // is released as part of Redis v8.2.x
         Assert.SkipWhen(endpointId == EndpointsFixture.Env.Cluster
                 && !EndpointsFixture.IsEnterprise
+                && EndpointsFixture.RedisVersion.Major == 8
                 && EndpointsFixture.RedisVersion.Minor < 4, "Ignoring cluster tests for FT.SEARCH pre Redis 8.4");
     }
 
@@ -1662,7 +1663,8 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
         Assert.NotNull(ex);
         Assert.IsType<RedisServerException>(ex);
-        Assert.Contains("no such index", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var fault = EndpointsFixture.IsAtLeast(8, 8) ? "index not found" : "no such index";
+        Assert.Contains(fault, ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     private int DatabaseSize(IDatabase db) => DatabaseSize(db, out _);

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -1728,7 +1728,8 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
         Assert.NotNull(ex);
         Assert.IsType<RedisServerException>(ex);
-        Assert.Contains("no such index", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var fault = EndpointsFixture.IsAtLeast(8, 8) ? "index not found" : "no such index";
+        Assert.Contains(fault, ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]

--- a/tests/dockers/.env.v8.8
+++ b/tests/dockers/.env.v8.8
@@ -1,0 +1,6 @@
+# Environment variables for Redis 8.8
+# Used by the run-tests GitHub Action
+
+# Redis CE image version (Redis 8+ includes modules natively)
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:unstable-23321515778-debian
+

--- a/tests/dockers/docker-compose.yml
+++ b/tests/dockers/docker-compose.yml
@@ -3,7 +3,7 @@
 services:
 
   redis:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.4-GA-pre.3}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:unstable-23321515778-debian}
     container_name: redis-standalone
     environment:
       - TLS_ENABLED=yes
@@ -21,7 +21,7 @@ services:
       - all
 
   cluster:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.4-GA-pre.3}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:unstable-23321515778-debian}
     container_name: redis-cluster
     environment:
       - REDIS_CLUSTER=yes


### PR DESCRIPTION
Back-compat validation for server 8.8; no functional changes - CI only; compensates for:

- changes to some search error messages (`no such index` becomes `index not found`, [from here](https://github.com/RediSearch/RediSearch/commit/3be2b69dee44e9f62578f56817ff1f8ac8f7d40e))
- changes to `info search` output (looks like a lot of internal detail sections removed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/docker test configuration and test assertions to accommodate Redis 8.8 output/message differences.
> 
> **Overview**
> Adds Redis `8.8` to the GitHub Actions integration test matrix and updates the docker test setup to use the `redislabs/client-libs-test:unstable-23321515778-debian` image (with a new `tests/dockers/.env.v8.8`).
> 
> Adjusts a few tests to be version-aware for Redis 8.8, including new `EndpointsFixture.IsAtLeast(...)` helper and updated assertions for `INFO search` output size and `FT.DROPINDEX` error message text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdfc87a3467f90b38f750eeccceb86ee54c450c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->