### PR TITLE
Allow running tests using custom images

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -3,65 +3,111 @@ description: 'Runs NRedisStack tests against different Redis versions and config
 inputs:
   dotnet-version:
     description: 'SDK version'
-    required: true
+    default: '10.0'
+    required: false
+  dotnet-quality:
+    description: 'SDK quality'
+    default: 'ga'
+    required: false
   redis-version:
     description: 'Redis version to test against (MAJOR.MINOR format, e.g., "7.4", "8.0")'
-    required: true
+    required: false
+    default: ''
   verify-nuget-package:
     description: 'Verify Nuget package'
     required: false
     default: 'false'
-  REDIS_CA_PEM:
-    description: 'Redis CA PEM'
-    required: true
-  REDIS_USER_CRT:
-    description: 'Redis User CRT'
-    required: true
-  REDIS_USER_PRIVATE_KEY:
-    description: 'Redis User Private Key'
-    required: true
+  client-libs-test-image-tag:
+    description: 'Tag of the client libs test image to use'
+    required: false
+    default: ''
+  client-libs-test-image:
+    description: 'Custom client libs test image name to use'
+    required: false
+    default: 'redislabs/client-libs-test'
+  # repository and ref are required for correct checkout when using action
+  # externally (e.g.: in redis-developer/redis-oss-release-automation)
+  repository:
+    description: 'Git repository to checkout'
+    required: false
+    default: ''
+  ref:
+    description: 'Git ref to checkout'
+    required: false
+    default: ''
+  upload-coverage:
+    description: 'Whether to upload coverage reports to Codecov'
+    required: false
+    default: 'true'
+  codecov-token:
+    description: 'Codecov token for uploading coverage'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
+
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          10.0.x
           ${{inputs.dotnet-version}}
-        dotnet-quality: 'ga'
+        dotnet-quality: '${{inputs.dotnet-quality}}'
 
     - name: Setup Environment variables and run Redis
       env:
         REDIS_VERSION: ${{ inputs.redis-version }}
+        INPUT_DOTNET_VERSION: ${{ inputs.dotnet-version }}
+        INPUT_CLIENT_LIBS_TEST_IMAGE_TAG: ${{ inputs.client-libs-test-image-tag }}
+        INPUT_CLIENT_LIBS_TEST_IMAGE: ${{ inputs.client-libs-test-image }}
       run: |
         set -e
 
         echo "::group::Setup Environment variables and run Redis"
-        dotnet_major_minor_version=$(echo "${{ inputs.dotnet-version }}" | grep -oP '^\d+\.\d+')
-        echo "CLR_VERSION=net${dotnet_major_minor_version}" >> $GITHUB_ENV
+        dotnet_major_minor_version=$(echo "$INPUT_DOTNET_VERSION" | grep -oP '^\d+\.\d+')
+        echo "CLR_VERSION=net${dotnet_major_minor_version}" | tee -a $GITHUB_ENV
 
-        # Load environment variables from version-specific file
-        ENV_FILE="tests/dockers/.env.v${REDIS_VERSION}"
-        if [[ ! -f "$ENV_FILE" ]]; then
-          echo "Environment file not found: $ENV_FILE"
+        compose_args=()
+        if [ -n "$INPUT_CLIENT_LIBS_TEST_IMAGE_TAG" ]; then
+          if [ -z "$INPUT_CLIENT_LIBS_TEST_IMAGE" ]; then
+            echo "Error: client-libs-test-image is required when client-libs-test-image-tag is set"
+            exit 1
+          fi
+          # CLIENT_LIBS_TEST_IMAGE is used by docker compose, note: it is full image url
+          export CLIENT_LIBS_TEST_IMAGE="$INPUT_CLIENT_LIBS_TEST_IMAGE:$INPUT_CLIENT_LIBS_TEST_IMAGE_TAG"
+          echo "CLIENT_LIBS_TEST_IMAGE=${CLIENT_LIBS_TEST_IMAGE}" >> $GITHUB_ENV
+          echo "Using custom client libs test image: ${CLIENT_LIBS_TEST_IMAGE}"
+        elif [ -n "${REDIS_VERSION}" ]; then
+          # Load environment variables from version-specific file
+          ENV_FILE="tests/dockers/.env.v${REDIS_VERSION}"
+          if [[ ! -f "$ENV_FILE" ]]; then
+            echo "Environment file not found: $ENV_FILE"
+            exit 1
+          fi
+          echo "Using environment file: $ENV_FILE"
+          compose_args=(--env-file "$ENV_FILE")
+        else
+          echo "Error: redis-version or client-libs-test-image-tag input is required"
           exit 1
         fi
-        echo "Using environment file: $ENV_FILE"
 
-        docker compose --env-file "$ENV_FILE" --profile all -f tests/dockers/docker-compose.yml up -d --build
+        docker compose "${compose_args[@]}" --profile all -f tests/dockers/docker-compose.yml up -d --quiet-pull --wait
         echo "::endgroup::"
       shell: bash
 
     # Make sure only the desired dotnet version is set both as target and as active SDK.
     - name: Tweak target frameworks
+      env:
+        INPUT_DOTNET_VERSION: ${{ inputs.dotnet-version }}
       shell: bash
       run: |
         find . -name '*.csproj' | xargs -I {} sed -E -i "s|<TargetFrameworks(.*)>.*</TargetFrameworks>|<TargetFramework\1>${CLR_VERSION}</TargetFramework>|" {}
         find . -name '*.csproj' | xargs cat
-        jq -n --arg version ${{inputs.dotnet-version}} '{"sdk":{"version":$version,"rollForward":"latestMinor"}}' > global.json
+        jq -n --arg version "$INPUT_DOTNET_VERSION" '{"sdk":{"version":$version,"rollForward":"latestMinor"}}' > global.json
     - name: Check .NET version
       shell: bash
       run: dotnet --version
@@ -85,22 +131,26 @@ runs:
         REDIS_VERSION: ${{ inputs.redis-version }}
       run: |
         echo "::group::Run tests"
-        echo "${{inputs.REDIS_CA_PEM}}" > tests/NRedisStack.Tests/bin/Debug/${CLR_VERSION}/redis_ca.pem
-        echo "${{inputs.REDIS_USER_CRT}}" > tests/NRedisStack.Tests/bin/Debug/${CLR_VERSION}/redis_user.crt
-        echo "${{inputs.REDIS_USER_PRIVATE_KEY}}" > tests/NRedisStack.Tests/bin/Debug/${CLR_VERSION}/redis_user_private.key
         REDIS_VERSION=$(echo "$REDIS_VERSION" | cut -d'-' -f1)
-        echo $REDIS_VERSION
+        if [ -n "${CLIENT_LIBS_TEST_IMAGE}" ]; then
+          # Redis version is usually set to 255.255.255 for custom images to reflect it is the latest available version.
+          echo "Image ${CLIENT_LIBS_TEST_IMAGE} (Redis version: ${REDIS_VERSION:-unstable})"
+        else
+          echo "Redis version: ${REDIS_VERSION}"
+        fi
         dotnet test -f ${CLR_VERSION} --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover -p:BuildInParallel=false tests/Test.proj --logger GitHubActions
         echo "::endgroup::"
     - name: Codecov
-      uses: codecov/codecov-action@v4
+      if: inputs.upload-coverage != 'false'
+      uses: codecov/codecov-action@v6
       with:
         verbose: true
+        token: ${{ inputs.codecov-token }}
     - name: Build
       shell: bash
       run: dotnet pack -c Release
 
-    - name: Test against Nuget package from local source      
+    - name: Test against Nuget package from local source
       if: inputs.verify-nuget-package == 'true'
       working-directory: PackageVerification
       shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,7 +53,7 @@ jobs:
       if: github.event.inputs.client-libs-test-image-tag != ''
       runs-on: ubuntu-latest
       timeout-minutes: 60
-      name: Custom image ${{ github.event.inputs.client-libs-test-image-tag }}
+      name: Custom image
       steps:
         - uses: actions/checkout@v6
         - name: Run tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,5 @@
 name: Integration Tests
+run-name: "Integration Tests${{ github.event.inputs.client-libs-test-image-tag != '' && format(' using image: {0}', github.event.inputs.client-libs-test-image-tag) || '' }}"
 
 on:
   push:
@@ -10,16 +11,25 @@ on:
   pull_request:
   schedule:
     - cron: "0 1 * * *"
+  workflow_dispatch:
+    inputs:
+      client-libs-test-image-tag:
+        description: 'Tag of the client libs test image to use'
+        required: false
+        default: ''
+      redis-version:
+        description: 'Redis version hint for the actual version installed in the custom image'
+        required: false
+        default: '255.255.255'
 
 concurrency:
   group: ${{ github.event.pull_request.number || github.ref }}-integration
   cancel-in-progress: true
 
-env:
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
     tests:
+      if: github.event.inputs.client-libs-test-image-tag == ''
       runs-on: ubuntu-latest
       timeout-minutes: 60
       strategy:
@@ -28,22 +38,34 @@ jobs:
         matrix:
           redis-version: [ '8.8', '8.6', '8.4', '8.2', '7.4', '7.2', '6.2']
           dotnet-version: ['8.0', '9.0', '10.0']
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       name: Redis ${{ matrix.redis-version }}; .NET ${{ matrix.dotnet-version }};
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: Run tests
           uses: ./.github/actions/run-tests
           with:
-              dotnet-version: ${{ matrix.dotnet-version }}              
+              dotnet-version: ${{ matrix.dotnet-version }}
               redis-version: ${{ matrix.redis-version }}
-              REDIS_CA_PEM: ${{ secrets.REDIS_CA_PEM }}
-              REDIS_USER_CRT: ${{ secrets.REDIS_USER_CRT }}
-              REDIS_USER_PRIVATE_KEY: ${{ secrets.REDIS_USER_PRIVATE_KEY }}
+              upload-coverage: 'true'
+              codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+    tests_custom_image:
+      if: github.event.inputs.client-libs-test-image-tag != ''
+      runs-on: ubuntu-latest
+      timeout-minutes: 60
+      name: Custom image ${{ github.event.inputs.client-libs-test-image-tag }}
+      steps:
+        - uses: actions/checkout@v6
+        - name: Run tests
+          uses: ./.github/actions/run-tests
+          with:
+              client-libs-test-image-tag: ${{ github.event.inputs.client-libs-test-image-tag }}
+              redis-version: ${{ github.event.inputs.redis-version }}
+              upload-coverage: 'false'
 
     build_and_test_windows:
       name: Windows Test ${{matrix.redis-stack-version}}
+      if: github.event.inputs.client-libs-test-image-tag == ''
       runs-on: windows-latest
       strategy:
         fail-fast: false
@@ -55,8 +77,8 @@ jobs:
         PASSWORD: ${{ secrets.PASSWORD }}
         ENDPOINT: ${{ secrets.ENDPOINT }}
       steps:
-        - uses: actions/checkout@v3
-        - uses: Vampire/setup-wsl@v2
+        - uses: actions/checkout@v6
+        - uses: Vampire/setup-wsl@v6
           with:
             distribution: Ubuntu-22.04
         - name: Install Redis
@@ -77,14 +99,14 @@ jobs:
             echo "${{secrets.REDIS_CA_PEM}}" > ${TARGET_DIR}/redis_ca.pem
             echo "${{secrets.REDIS_USER_CRT}}" > ${TARGET_DIR}/redis_user.crt
             echo "${{secrets.REDIS_USER_PRIVATE_KEY}}" > ${TARGET_DIR}redis_user_private.key
-            
-            # We need to remove the cluster endpoint from the endpoints.json file 
+
+            # We need to remove the cluster endpoint from the endpoints.json file
             # because we run only standalone redis-stack-server.
             jq 'del(.cluster)' tests/dockers/endpoints.json > standalone_only.json
             rm tests/dockers/endpoints.json && cp standalone_only.json tests/dockers/endpoints.json
             cp -f standalone_only.json ${TARGET_DIR}/endpoints.json
             cat tests/dockers/endpoints.json
-            cat ${TARGET_DIR}/endpoints.json            
+            cat ${TARGET_DIR}/endpoints.json
         - name: Run redis-server
           shell: wsl-bash {0}
           run: |


### PR DESCRIPTION
# The main idea of the changes

* Allow running tests against arbitrary client libs image tag and not just hardcoded versions.
* Enable run-tests action usage from the external repository

run-tests action would be run nightly against redis unstable builds and when someone requests custom server build.
Workflow would run in redis-oss-release-automation repository, like [this](https://github.com/redis-developer/redis-oss-release-automation/actions/runs/24135746731/job/70423319354)

# Specifying Redis Version and Image

New inputs: `client-libs-test-image-tag` and `client-libs-test-image` are provided in run-tests action.

`redis-version` input is now optional. However action would fail if neither `redis-version` nor `client-libs-test-image-tag` were specified.

`client-libs-test-image` is a base image name, e.g. redislabsdev/client-libs-test-image. Currently default value is always used.

client-libs-test-image-tag is a tag name, this input takes precedence over `redis-version`.

`client-lib-test-image` input and `CLIENT_LIBS_TEST_IMAGE` variable naming (used in docker compose) could be a bit confusing, since input is base image name, but variable is fully qualifed name inluding image tag. If it's not OK, we can rename it somehow, I just didn't have any better idea.

When `client-libs-test-image-tag` is used, `redis-version` is set to 255.255.255 by default, that should indicate for tests that the redis version is latest. According to how REDIS_VERSION variable is handled by tests it should be fine, but I'm not sure.

# Other changes

Removed TLS related variables and file creation from run-tests action. I believe this was intended for different scenario, perhaps external cluster and it couldn't be used with the client libs image, since the image has it's own emdedded PKI.

Updated all action versions to newer versions supporting node24, according to not very deep research there were no any breaking changes. No deprecation warnings anymore.

`dotnet-version` in run-action now has default value of "10.0" and default `dotnet-quality=ga`. This allows to run action externally relying on whatever default version is set by you. It doesn't affect matrix run which sets dotnet versions explicitly.

`dotnet-quality` was added for convenience to be able to set it if required, currently default "ga" is used as before.

Added workflow_dispatch to `integration.yml`. It runs tests_custom_image job. This is just for convinence to be able to run integration using custom image.

Added `--wait` (wait for readyness) and `--quiet-pull` (less noisy output) arguments to docker compose up, `--build` was removed.

Direct usage of `${{ }}` substitutions in shell code was replaced by shell variables to avoid potential injections, it's low risk but may arise in certain situations.

Upload coverage is now controlled by `upload-coverage` input, this allows to skip this step when using action externally. In addition token is passed to the action explicitly as input.





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes in the shared `run-tests` composite action (checkout, docker compose startup, coverage upload gating), which could break workflows or reduce test signal if misconfigured. No product/runtime code changes, but the pipeline logic is central to validating releases.
> 
> **Overview**
> Enables running integration tests against an arbitrary `client-libs-test` Docker image tag (and optional base image), making `redis-version` optional but required if no custom image is provided.
> 
> Updates the `run-tests` composite action to support external checkout via `repository`/`ref`, parameterize `.NET` version/quality defaults, start docker-compose with `--wait`/`--quiet-pull`, and gate Codecov uploads behind a new `upload-coverage` input with an explicit `codecov-token`.
> 
> Extends `integration.yml` with `workflow_dispatch` to run a dedicated custom-image job, while keeping the existing matrix jobs for normal runs; also bumps GitHub Action versions (checkout/setup-dotnet/codecov/setup-wsl) and removes the previously-required TLS secret inputs from the composite action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9165c94b0ae314d6c3dd9328c0b3ee476524b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->