### PR TITLE
move CI to m03

### DIFF
--- a/.github/ci.csproj
+++ b/.github/ci.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.3.0">
-    <!-- this is actually here just to serve as a hub for docs, so we don't need to keep editing the sln-->
+    <!-- this is actually here just to serve as a hub for github actions, so we don't need to keep editing the sln-->
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>

--- a/.github/ci.csproj
+++ b/.github/ci.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.3.0">
-    <!-- this is actually here just to serve as a hub for .github, so we don't need to keep editing the sln-->
+    <!-- this is actually here just to serve as a hub for docs, so we don't need to keep editing the sln-->
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>

--- a/NRedisStack.sln
+++ b/NRedisStack.sln
@@ -15,12 +15,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{84D6210F
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		version.json = version.json
-		tests\dockers\docker-compose.yml = tests\dockers\docker-compose.yml
 		.github\actions\run-tests\action.yml = .github\actions\run-tests\action.yml
 		.github\workflows\integration.yml = .github\workflows\integration.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "docs", "docs\docs.csproj", "{4A35FC3C-69BC-4BDB-A4B2-6BFD0DF215AD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ci", ".github\ci.csproj", "{7524BE44-2B46-454F-80B5-BF131927D948}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dockers", "tests\dockers\dockers.csproj", "{7675B578-9759-4860-B9DC-31FECA809A42}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,5 +50,17 @@ Global
 		{4A35FC3C-69BC-4BDB-A4B2-6BFD0DF215AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4A35FC3C-69BC-4BDB-A4B2-6BFD0DF215AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4A35FC3C-69BC-4BDB-A4B2-6BFD0DF215AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7524BE44-2B46-454F-80B5-BF131927D948}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7524BE44-2B46-454F-80B5-BF131927D948}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7524BE44-2B46-454F-80B5-BF131927D948}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7524BE44-2B46-454F-80B5-BF131927D948}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7675B578-9759-4860-B9DC-31FECA809A42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7675B578-9759-4860-B9DC-31FECA809A42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7675B578-9759-4860-B9DC-31FECA809A42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7675B578-9759-4860-B9DC-31FECA809A42}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{7524BE44-2B46-454F-80B5-BF131927D948} = {84D6210F-9A65-427A-965F-57E7B76424AB}
+		{7675B578-9759-4860-B9DC-31FECA809A42} = {84D6210F-9A65-427A-965F-57E7B76424AB}
 	EndGlobalSection
 EndGlobal

--- a/docs/docs.csproj
+++ b/docs/docs.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.3.0">
-    <!-- this is actually here just to serve as a hub for .github, so we don't need to keep editing the sln-->
+    <!-- this is actually here just to serve as a hub for docs, so we don't need to keep editing the sln-->
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>

--- a/tests/NRedisStack.Tests/CommunityEditionUpdatesTests.cs
+++ b/tests/NRedisStack.Tests/CommunityEditionUpdatesTests.cs
@@ -104,7 +104,7 @@ public class CommunityEditionUpdatesTests : AbstractNRedisStackTest, IDisposable
 
         var searchInfo = server.Info("search");
         // v8.8 reduces a lot of noise around "info search" output
-        var expectCount = EndpointsFixture.IsAtLeast(8, 8) ? 2 : 8;
+        var expectCount = EndpointsFixture.IsAtLeast(ServerVersion.Redis_8_8) ? 2 : 8;
         CustomAssertions.GreaterThan(searchInfo.Length, expectCount);
     }
 

--- a/tests/NRedisStack.Tests/EndpointsFixture.cs
+++ b/tests/NRedisStack.Tests/EndpointsFixture.cs
@@ -67,6 +67,9 @@ public class EndpointsFixture : IDisposable
 
     public static Version RedisVersion = new(Environment.GetEnvironmentVariable("REDIS_VERSION") ?? "0.0.0");
 
+    public static bool IsAtLeast(Version version)
+        => IsAtLeast(version.Major, version.Minor, version.Build, version.Revision);
+
     public static bool IsAtLeast(int major, int minor = 0, int build = 0, int revision = 0)
     {
         var version = RedisVersion;

--- a/tests/NRedisStack.Tests/Json/JsonTests.cs
+++ b/tests/NRedisStack.Tests/Json/JsonTests.cs
@@ -134,7 +134,7 @@ public class JsonTests(EndpointsFixture endpointsFixture) : AbstractNRedisStackT
     [MemberData(nameof(FphaTestData))]
     public void TestJsonSetFpha(string endpointId, JsonNumericArrayStorage fpha)
     {
-        Assert.SkipUnless(fpha is JsonNumericArrayStorage.NotSpecified || EndpointsFixture.IsAtLeast(8, 8), "FPHA is not supported");
+        Assert.SkipUnless(fpha is JsonNumericArrayStorage.NotSpecified || EndpointsFixture.IsAtLeast(ServerVersion.Redis_8_8), "FPHA is not supported");
         var db = GetCleanDatabase(endpointId);
 
         double[] original = [1.0, 2.0, 3.0];
@@ -150,7 +150,7 @@ public class JsonTests(EndpointsFixture endpointsFixture) : AbstractNRedisStackT
     [MemberData(nameof(FphaTestData))]
     public async Task TestJsonSetFphaAsync(string endpointId, JsonNumericArrayStorage fpha)
     {
-        Assert.SkipUnless(fpha is JsonNumericArrayStorage.NotSpecified || EndpointsFixture.IsAtLeast(8, 8), "FPHA is not supported");
+        Assert.SkipUnless(fpha is JsonNumericArrayStorage.NotSpecified || EndpointsFixture.IsAtLeast(ServerVersion.Redis_8_8), "FPHA is not supported");
         var db = GetCleanDatabase(endpointId);
 
         double[] original = [1.0, 2.0, 3.0];

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -1728,7 +1728,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
         Assert.NotNull(ex);
         Assert.IsType<RedisServerException>(ex);
-        var fault = EndpointsFixture.IsAtLeast(8, 8) ? "index not found" : "no such index";
+        var fault = EndpointsFixture.IsAtLeast(ServerVersion.Redis_8_8) ? "index not found" : "no such index";
         Assert.Contains(fault, ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -1663,7 +1663,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
         Assert.NotNull(ex);
         Assert.IsType<RedisServerException>(ex);
-        var fault = EndpointsFixture.IsAtLeast(8, 8) ? "index not found" : "no such index";
+        var fault = EndpointsFixture.IsAtLeast(ServerVersion.Redis_8_8) ? "index not found" : "no such index";
         Assert.Contains(fault, ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/tests/NRedisStack.Tests/ServerVersion.cs
+++ b/tests/NRedisStack.Tests/ServerVersion.cs
@@ -1,7 +1,7 @@
 namespace NRedisStack.Tests;
 
 public static class ServerVersion
-{    
+{
     // we might be able to remove this in the future - there is a suggestion that there is a
     // formal policy to start milestones at 224 (so 8.7.224 is *effectively* 8.8.0-pre-alpha)
     public static Version Redis_8_8 = new(8, 7, 226);

--- a/tests/NRedisStack.Tests/ServerVersion.cs
+++ b/tests/NRedisStack.Tests/ServerVersion.cs
@@ -1,0 +1,8 @@
+namespace NRedisStack.Tests;
+
+public static class ServerVersion
+{    
+    // we might be able to remove this in the future - there is a suggestion that there is a
+    // formal policy to start milestones at 224 (so 8.7.224 is *effectively* 8.8.0-pre-alpha)
+    public static Version Redis_8_8 = new(8, 7, 226);
+}

--- a/tests/dockers/.env.v8.8
+++ b/tests/dockers/.env.v8.8
@@ -2,5 +2,5 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:unstable-23321515778-debian
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.8-m03
 

--- a/tests/dockers/docker-compose.yml
+++ b/tests/dockers/docker-compose.yml
@@ -3,7 +3,7 @@
 services:
 
   redis:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:unstable-23321515778-debian}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-m03}
     container_name: redis-standalone
     environment:
       - TLS_ENABLED=yes
@@ -21,7 +21,7 @@ services:
       - all
 
   cluster:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:unstable-23321515778-debian}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-m03}
     container_name: redis-cluster
     environment:
       - REDIS_CLUSTER=yes

--- a/tests/dockers/dockers.csproj
+++ b/tests/dockers/dockers.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.3.0">
-    <!-- this is actually here just to serve as a hub for .github, so we don't need to keep editing the sln-->
+    <!-- this is actually here just to serve as a hub for dockers, so we don't need to keep editing the sln-->
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
- move CI to m03
- fix versioning snafu re m03 reporting 8.7.226
- make it easier to edit the CI files from the sln

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/docker configuration and test-only version checks, with no impact on production library code. Main risk is CI flakiness if the pinned `8.8-m03` image behavior diverges from expectations.
> 
> **Overview**
> Updates the docker-based integration test setup to use `redislabs/client-libs-test:8.8-m03` (including `.env.v8.8` and default `docker-compose.yml`), aligning CI with the Redis 8.8 milestone image.
> 
> Adjusts test version gating for Redis 8.8 by introducing `ServerVersion.Redis_8_8 = 8.7.226` and adding an `EndpointsFixture.IsAtLeast(Version)` overload, then switching several tests to use this constant for feature/behavior expectations.
> 
> Adds lightweight `NoTargets` “hub” projects (`.github/ci.csproj`, `tests/dockers/dockers.csproj`) and wires them into `NRedisStack.sln` to make CI/docker files easier to edit from the solution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84bacb952c1cd77f467f908dd07a02fa724720ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->