### PR TITLE
Marc/resp3

### DIFF
--- a/src/NRedisStack/ResponseParser.cs
+++ b/src/NRedisStack/ResponseParser.cs
@@ -875,10 +875,31 @@ internal static class ResponseParser
     public static Tuple<SearchResult, Dictionary<string, RedisResult>> ToProfileSearchResult(this RedisResult result, Query q)
     {
         var results = (RedisResult[])result!;
-
-        var searchResult = results[0].ToSearchResult(q);
-        var profile = results[1].ToStringRedisResultDictionary();
-        return new(searchResult, profile);
+        SearchResult? searchResult = null;
+        Dictionary<string, RedisResult>? profile = null;
+        if (result.Resp3Type is ResultType.Map)
+        {
+            // RESP3: keyed sections map
+            for (int i = 0; i + 1 < results.Length; i += 2)
+            {
+                switch (results[i].ToString())
+                {
+                    case "Results":
+                        results[i + 1].ToSearchResult(q);
+                        break;
+                    case "Profile": 
+                        profile = results[i + 1].ToStringRedisResultDictionary();
+                        break;
+                }
+            }
+        }
+        else
+        {
+            // RESP2: ordered array
+            searchResult = results[0].ToSearchResult(q);
+            profile = results[1].ToStringRedisResultDictionary();
+        }
+        return new(searchResult!, profile!);
     }
 
     public static Tuple<SearchResult, ProfilingInformation> ParseProfileSearchResult(this RedisResult result, Query q)

--- a/src/NRedisStack/ResponseParser.cs
+++ b/src/NRedisStack/ResponseParser.cs
@@ -650,12 +650,29 @@ internal static class ResponseParser
 
     public static Dictionary<string, string> ToConfigDictionary(this RedisResult value)
     {
-        var res = (RedisResult[])value!;
-        var dict = new Dictionary<string, string>();
-        foreach (var pair in res)
+        Dictionary<string, string> dict;
+        if (value.Length is 0)
         {
-            var arr = (RedisResult[])pair!;
-            dict.Add(arr[0].ToString(), arr[1].ToString());
+            dict = new(0);
+        }
+        else if (value.Resp3Type is ResultType.Map)
+        {
+            // RESP3: map
+            dict = new(value.Length / 2);
+            for (int i = 0; i + 1 < value.Length; i += 2)
+            {
+                dict.Add(value[i].ToString(), value[i + 1].ToString());
+            }
+        }
+        else
+        {
+            // RESP2: jagged; [ [key, value] ]
+            dict = new(value.Length);
+            for (int i = 0 ; i < value.Length ; i += 2)
+            {
+                var inner = value[i];
+                dict.Add(inner[0].ToString(), inner[1].ToString());
+            }
         }
         return dict;
     }

--- a/tests/NRedisStack.Tests/AbstractNRedisStackTest.cs
+++ b/tests/NRedisStack.Tests/AbstractNRedisStackTest.cs
@@ -11,10 +11,16 @@ public abstract class AbstractNRedisStackTest : IClassFixture<EndpointsFixture>,
     private protected EndpointsFixture EndpointsFixture { get; }
     private readonly ITestOutputHelper? log;
 
-    protected void Log(string message)
+    protected void Log(string message, bool demand = true)
     {
-        if (log is null) throw new InvalidOperationException("Log is not initialized");
-        log.WriteLine(message);
+        if (log is null)
+        {
+            if (demand) throw new InvalidOperationException("Log is not initialized");
+        }
+        else
+        {
+            log.WriteLine(message);
+        }
     }
 
     protected readonly ConfigurationOptions DefaultConnectionConfig = new()
@@ -28,6 +34,30 @@ public abstract class AbstractNRedisStackTest : IClassFixture<EndpointsFixture>,
     {
         this.EndpointsFixture = endpointsFixture;
         this.log = log;
+    }
+
+    protected void AssertVersion(IDatabase db, [CallerMemberName] string testName = "")
+    {
+        // this is used to reapply "Skip" logic after auto-discovery of the server version is possible
+        var attributes = GetType().GetMethod(testName)?.GetCustomAttributes(true) ?? [];
+        Version? version = null;
+        foreach (var attribute in attributes)
+        {
+            SkipIfRedisCore? core = attribute switch
+            {
+                SkipIfRedisFactAttribute fact => fact.Core,
+                SkipIfRedisTheoryAttribute theory => theory.Core,
+                _ => null,
+            };
+            if (core is { } defined)
+            {
+                // get the actual redis version and use that to recheck
+                version ??= db.Multiplexer.GetServer((RedisKey)"any key").Version;
+                Log($"Validating with detected server version: {version}", demand: false);
+                var skip = defined.GetSkip(version);
+                Assert.SkipWhen(skip is not null, skip ?? "");
+            }
+        }
     }
 
     protected ConnectionMultiplexer GetConnection(string endpointId = EndpointsFixture.Env.Standalone, bool shareConnection = true) => EndpointsFixture.GetConnectionById(this.DefaultConnectionConfig, endpointId, shareConnection);

--- a/tests/NRedisStack.Tests/PipelineTests.cs
+++ b/tests/NRedisStack.Tests/PipelineTests.cs
@@ -20,6 +20,7 @@ public class PipelineTests : AbstractNRedisStackTest, IDisposable
     public void TestModulesPipeline(string endpointId)
     {
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var pipeline = new Pipeline(db);
 
         _ = pipeline.Bf.ReserveAsync("bf-key", 0.001, 100);

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -1194,6 +1194,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     public void TestConfig(string endpointId)
     {
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
         Assert.True(ft.ConfigSet("TIMEOUT", "100"));
         Dictionary<string, string> configMap = ft.ConfigGet("*");
@@ -1206,6 +1207,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     public async Task TestConfigAsnyc(string endpointId)
     {
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
         Assert.True(await ft.ConfigSetAsync("TIMEOUT", "100"));
         Dictionary<string, string> configMap = await ft.ConfigGetAsync("*");
@@ -1218,6 +1220,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     public void configOnTimeout(string endpointId)
     {
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
         Assert.True(ft.ConfigSet("ON_TIMEOUT", "fail"));
         Assert.Equal("fail", ft.ConfigGet("ON_TIMEOUT")["ON_TIMEOUT"]);
@@ -1237,6 +1240,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     public async Task configOnTimeoutAsync(string endpointId)
     {
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
         Assert.True(await ft.ConfigSetAsync("ON_TIMEOUT", "fail"));
         Assert.Equal("fail", (await ft.ConfigGetAsync("ON_TIMEOUT"))["ON_TIMEOUT"]);
@@ -1256,6 +1260,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     public void TestDialectConfig(string endpointId)
     {
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
         // confirm default
         var result = ft.ConfigGet("DEFAULT_DIALECT");
@@ -1279,6 +1284,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     public async Task TestDialectConfigAsync(string endpointId)
     {
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
         // confirm default
         var result = await ft.ConfigGetAsync("DEFAULT_DIALECT");
@@ -3288,6 +3294,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     {
         SkipClusterPre8(endpointId);
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
 
         Schema sc = new Schema().AddTextField("t1", 1.0).AddTextField("t2", 1.0);
@@ -3309,6 +3316,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     {
         SkipClusterPre8(endpointId);
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
 
         Schema sc = new Schema().AddTextField("t1", 1.0).AddTextField("t2", 1.0);
@@ -3402,6 +3410,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     {
         SkipClusterPre8(endpointId);
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
 
         ft.Create(index, new Schema().AddTextField("t")); // Calling FT.CREATR without FTCreateParams
@@ -3433,6 +3442,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     {
         SkipClusterPre8(endpointId);
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var ft = db.FT();
 
         await ft.CreateAsync(index, new Schema().AddTextField("t")); // Calling FT.CREATR without FTCreateParams

--- a/tests/NRedisStack.Tests/SkipIfRedisTheoryAttribute.cs
+++ b/tests/NRedisStack.Tests/SkipIfRedisTheoryAttribute.cs
@@ -44,58 +44,57 @@ internal readonly struct SkipIfRedisCore
         _targetVersion = targetVersion;
     }
 
-    public string? Skip
+    public string? Skip => GetSkip(EndpointsFixture.RedisVersion);
+
+    public string? GetSkip(Version redisVersion)
     {
-        get
+        string skipReason = "";
+        bool skipped = false;
+
+        foreach (var environment in _environments)
         {
-            string skipReason = "";
-            bool skipped = false;
-
-            foreach (var environment in _environments)
+            switch (environment)
             {
-                switch (environment)
-                {
-                    case Is.Enterprise:
-                        if (EndpointsFixture.IsEnterprise)
-                        {
-                            skipReason = skipReason + " Redis Enterprise environment.";
-                            skipped = true;
-                        }
-
-                        break;
-                }
-            }
-
-            var targetVersion = new Version(_targetVersion);
-            int comparisonResult = EndpointsFixture.RedisVersion.CompareTo(targetVersion);
-
-            switch (_comparison)
-            {
-                case Comparison.LessThan:
-                    if (comparisonResult < 0)
+                case Is.Enterprise:
+                    if (EndpointsFixture.IsEnterprise)
                     {
-                        skipReason = skipReason +
-                                     $" Redis server version ({EndpointsFixture.RedisVersion}) is less than {_targetVersion}.";
-                        skipped = true;
-                    }
-
-                    break;
-                case Comparison.GreaterThanOrEqual:
-                    if (comparisonResult >= 0)
-                    {
-                        skipReason = skipReason +
-                                     $" Redis server version ({EndpointsFixture.RedisVersion}) is greater than or equal to {_targetVersion}.";
+                        skipReason = skipReason + " Redis Enterprise environment.";
                         skipped = true;
                     }
 
                     break;
             }
-
-
-            if (skipped)
-                return "Test skipped, because:" + skipReason;
-            return null;
         }
+
+        var targetVersion = new Version(_targetVersion);
+        int comparisonResult = redisVersion.CompareTo(targetVersion);
+
+        switch (_comparison)
+        {
+            case Comparison.LessThan:
+                if (comparisonResult < 0)
+                {
+                    skipReason = skipReason +
+                                 $" Redis server version ({redisVersion}) is less than {_targetVersion}.";
+                    skipped = true;
+                }
+
+                break;
+            case Comparison.GreaterThanOrEqual:
+                if (comparisonResult >= 0)
+                {
+                    skipReason = skipReason +
+                                 $" Redis server version ({redisVersion}) is greater than or equal to {_targetVersion}.";
+                    skipped = true;
+                }
+
+                break;
+        }
+
+
+        if (skipped)
+            return "Test skipped, because:" + skipReason;
+        return null;
     }
 }
 
@@ -129,6 +128,8 @@ public class TheoryAttribute(
 [XunitTestCaseDiscoverer(typeof(ExpandingTheoryDiscoverer))]
 public class SkipIfRedisTheoryAttribute : TheoryAttribute
 {
+    internal SkipIfRedisCore Core { get; }
+
     public SkipIfRedisTheoryAttribute(
         Is environment,
         Comparison comparison = Comparison.LessThan,
@@ -136,8 +137,8 @@ public class SkipIfRedisTheoryAttribute : TheoryAttribute
         [CallerFilePath] string? sourceFilePath = null,
         [CallerLineNumber] int sourceLineNumber = -1) : base(sourceFilePath, sourceLineNumber)
     {
-        SkipIfRedisCore core = new(environment, comparison, targetVersion);
-        Skip = core.Skip;
+        Core = new(environment, comparison, targetVersion);
+        Skip = Core.Skip;
     }
 
     public SkipIfRedisTheoryAttribute(
@@ -145,8 +146,8 @@ public class SkipIfRedisTheoryAttribute : TheoryAttribute
         [CallerFilePath] string? sourceFilePath = null,
         [CallerLineNumber] int sourceLineNumber = -1) : base(sourceFilePath, sourceLineNumber) // defaults to LessThan
     {
-        SkipIfRedisCore core = new(targetVersion);
-        Skip = core.Skip;
+        Core = new(targetVersion);
+        Skip = Core.Skip;
     }
 
     public SkipIfRedisTheoryAttribute(
@@ -154,8 +155,8 @@ public class SkipIfRedisTheoryAttribute : TheoryAttribute
         [CallerFilePath] string? sourceFilePath = null,
         [CallerLineNumber] int sourceLineNumber = -1) : base(sourceFilePath, sourceLineNumber)
     {
-        SkipIfRedisCore core = new(comparison, targetVersion);
-        Skip = core.Skip;
+        Core = new(comparison, targetVersion);
+        Skip = Core.Skip;
     }
 }
 
@@ -190,17 +191,19 @@ public class SkipIfRedisFactAttribute : FactAttribute
         [CallerFilePath] string? sourceFilePath = null,
         [CallerLineNumber] int sourceLineNumber = -1) : base(sourceFilePath, sourceLineNumber)
     {
-        SkipIfRedisCore core = new(environment, comparison, targetVersion);
-        Skip = core.Skip;
+        Core = new(environment, comparison, targetVersion);
+        Skip = Core.Skip;
     }
+
+    internal SkipIfRedisCore Core { get; } 
 
     public SkipIfRedisFactAttribute( // defaults to LessThan
         string targetVersion,
         [CallerFilePath] string? sourceFilePath = null,
         [CallerLineNumber] int sourceLineNumber = -1) : base(sourceFilePath, sourceLineNumber)
     {
-        SkipIfRedisCore core = new(targetVersion);
-        Skip = core.Skip;
+        Core = new(targetVersion);
+        Skip = Core.Skip;
     }
 
     public SkipIfRedisFactAttribute(
@@ -209,8 +212,8 @@ public class SkipIfRedisFactAttribute : FactAttribute
         [CallerFilePath] string? sourceFilePath = null,
         [CallerLineNumber] int sourceLineNumber = -1) : base(sourceFilePath, sourceLineNumber)
     {
-        SkipIfRedisCore core = new(comparison, targetVersion);
-        Skip = core.Skip;
+        Core = new(comparison, targetVersion);
+        Skip = Core.Skip;
     }
 }
 

--- a/tests/NRedisStack.Tests/TimeSeries/TestDataTypes/TestTimeSeriesInformation.cs
+++ b/tests/NRedisStack.Tests/TimeSeries/TestDataTypes/TestTimeSeriesInformation.cs
@@ -9,14 +9,15 @@ using NRedisStack.Tests;
 
 namespace NRedisTimeSeries.Test.TestDataTypes;
 
-public class TestInformation(EndpointsFixture endpointsFixture)
-    : AbstractNRedisStackTest(endpointsFixture)
+public class TestInformation(EndpointsFixture endpointsFixture, ITestOutputHelper log)
+    : AbstractNRedisStackTest(endpointsFixture, log)
 {
     [SkipIfRedisFact(Comparison.GreaterThanOrEqual, "7.9.240")]
     public void TestInformationSync()
     {
         string key = CreateKeyName();
         IDatabase db = GetCleanDatabase();
+        AssertVersion(db);
         var ts = db.TS();
         ts.Add(key, "*", 1.1);
         ts.Add(key, "*", 1.3, duplicatePolicy: TsDuplicatePolicy.LAST);
@@ -42,6 +43,7 @@ public class TestInformation(EndpointsFixture endpointsFixture)
     {
         string key = CreateKeyName();
         IDatabase db = GetCleanDatabase();
+        AssertVersion(db);
         var ts = db.TS();
         await ts.AddAsync(key, "*", 1.1);
         await ts.AddAsync(key, "*", 1.3, duplicatePolicy: TsDuplicatePolicy.LAST);

--- a/tests/NRedisStack.Tests/TransactionsTests.cs
+++ b/tests/NRedisStack.Tests/TransactionsTests.cs
@@ -39,6 +39,7 @@ public class TransactionTests : AbstractNRedisStackTest, IDisposable
     public void TestModulesTransaction(string endpointId)
     {
         IDatabase db = GetCleanDatabase(endpointId);
+        AssertVersion(db);
         var tran = new Transaction(db);
 
         _ = tran.Bf.ReserveAsync("bf-key", 0.001, 100);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes parsing logic for Redis responses (RESP2 vs RESP3) which can affect runtime behavior across modules, plus updates test skip/version detection that may change which integration tests run. Risk is moderate due to protocol-variant handling and potential null/shape assumptions in response parsing.
> 
> **Overview**
> Updates `ResponseParser` to correctly parse both RESP2 and RESP3 shapes for `FT.CONFIG` results (`ToConfigDictionary`) and RediSearch profiling output (`ToProfileSearchResult`) when RESP3 returns keyed maps instead of ordered/jagged arrays.
> 
> Refactors test skip attributes to expose their underlying `SkipIfRedisCore` and adds `AbstractNRedisStackTest.AssertVersion()` to re-check skip conditions using the *actual* server version discovered from the connection; several integration tests now call this to avoid running against unsupported Redis versions, and logging is made optional for tests that don’t provide an output helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a4de54242d59513b65fa2327c9b26fb4f5e4316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->