### PR TITLE
update CI matrix to latest GA minors

### DIFF
--- a/tests/NRedisStack.Tests/CommunityEditionUpdatesTests.cs
+++ b/tests/NRedisStack.Tests/CommunityEditionUpdatesTests.cs
@@ -103,9 +103,7 @@ public class CommunityEditionUpdatesTests : AbstractNRedisStackTest, IDisposable
         IServer server = getAnyPrimary(muxer);
 
         var searchInfo = server.Info("search");
-        // v8.8 reduces a lot of noise around "info search" output
-        var expectCount = EndpointsFixture.IsAtLeast(ServerVersion.Redis_8_8) ? 2 : 8;
-        CustomAssertions.GreaterThan(searchInfo.Length, expectCount);
+        CustomAssertions.GreaterThan(searchInfo.Length, 2); // just: something
     }
 
 }

--- a/tests/dockers/.env.v7.2
+++ b/tests/dockers/.env.v7.2
@@ -2,4 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis Stack image version for module tests
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:rs-7.2.14
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:7.2.14

--- a/tests/dockers/.env.v7.2
+++ b/tests/dockers/.env.v7.2
@@ -2,4 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis Stack image version for module tests
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:7.2.14
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:rs-7.2.0-v20

--- a/tests/dockers/.env.v7.2
+++ b/tests/dockers/.env.v7.2
@@ -2,5 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis Stack image version for module tests
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:rs-7.2.0-v20
-
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:rs-7.2.14

--- a/tests/dockers/.env.v7.4
+++ b/tests/dockers/.env.v7.4
@@ -2,5 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis Stack image version for module tests
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:rs-7.4.9
-
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:7.4.9

--- a/tests/dockers/.env.v7.4
+++ b/tests/dockers/.env.v7.4
@@ -2,5 +2,5 @@
 # Used by the run-tests GitHub Action
 
 # Redis Stack image version for module tests
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:rs-7.4.0-v8
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:rs-7.4.9
 

--- a/tests/dockers/.env.v7.4
+++ b/tests/dockers/.env.v7.4
@@ -2,4 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis Stack image version for module tests
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:7.4.9
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:rs-7.4.0-v8

--- a/tests/dockers/.env.v8.0
+++ b/tests/dockers/.env.v8.0
@@ -2,5 +2,5 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.0.5
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.0.6
 

--- a/tests/dockers/.env.v8.2
+++ b/tests/dockers/.env.v8.2
@@ -2,5 +2,5 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.2.3
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.2.6
 

--- a/tests/dockers/.env.v8.4
+++ b/tests/dockers/.env.v8.4
@@ -2,5 +2,5 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.4.0
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.4.3
 

--- a/tests/dockers/.env.v8.6
+++ b/tests/dockers/.env.v8.6
@@ -2,5 +2,5 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.6.0
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.6.3
 


### PR DESCRIPTION
use latest GA images from client-libs-test

inspired by breaking changes in 8.6.3, [here](https://github.com/StackExchange/StackExchange.Redis/pull/3073)

Open question on 7.2 and 7.4: whether to:

- prefer the older `rs-` builds that *include* `FT.SEARCH`
- prefer the newer GA builds, and disable `FT.SEARCH`
- something else

decision: stick with the older rs builds for v7


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because CI/runtime test coverage is being moved to newer Redis images, which can introduce behavior changes and new failures. Code changes are limited to test expectations and docker env pins.
> 
> **Overview**
> Updates the docker test matrix to newer `redislabs/client-libs-test` GA images for Redis CE `8.0`, `8.2`, `8.4`, and `8.6`, keeping `7.2`/`7.4` pins unchanged.
> 
> Relaxes `CommunityEditionUpdatesTests.InfoSearchSection` to assert only that `INFO search` returns *some* output (length `> 2`), removing version-specific expectations about section noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271a158a1011a41c04e4631069c883c13143551c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->