### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,6 +26,8 @@ concurrency:
   group: ${{ github.event.pull_request.number || github.ref }}-integration
   cancel-in-progress: true
 
+permissions:
+  contents: read
 
 jobs:
     tests:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.event.pull_request.number || github.ref }}-linter
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   dotnet-format:
     runs-on: windows-latest

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.event.pull_request.number || github.ref }}-spellcheck
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check-spelling:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that reduces GitHub token permissions without altering build/test logic; failures would be limited to workflows that unexpectedly need additional permissions.
> 
> **Overview**
> Adds workflow-level `permissions: contents: read` to `integration.yml`, `linter.yaml`, and `spellcheck.yml`, explicitly limiting the default `GITHUB_TOKEN` scope to read-only repository contents for these jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa019c8b02a9fd054c2adbe7cca49e10e7acffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->