### PR TITLE
Bump 8.8 image

### DIFF
--- a/tests/dockers/.env.v8.8
+++ b/tests/dockers/.env.v8.8
@@ -2,4 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.8-rc1
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:custom-26235535976-debian

--- a/tests/dockers/docker-compose.yml
+++ b/tests/dockers/docker-compose.yml
@@ -3,7 +3,7 @@
 services:
 
   redis:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-rc1}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:custom-26235535976-debian}
     container_name: redis-standalone
     environment:
       - TLS_ENABLED=yes
@@ -21,7 +21,7 @@ services:
       - all
 
   cluster:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-rc1}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:custom-26235535976-debian}
     container_name: redis-cluster
     environment:
       - REDIS_CLUSTER=yes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only test Docker image tags change; no application or runtime code is affected.
> 
> **Overview**
> Updates the Redis **8.8** test stack to use a custom `client-libs-test` image (`custom-26235535976-debian`) instead of `8.8-rc1`.
> 
> The new tag is set in `tests/dockers/.env.v8.8` and as the default in `tests/dockers/docker-compose.yml` for both **standalone** and **cluster** services, so CI and local compose runs pull the same image when `CLIENT_LIBS_TEST_IMAGE` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd096b1fa50f9a516b270ae449207df8f54ab72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->