### PR TITLE
Upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -17,7 +17,7 @@ jobs:
         run: dotnet tool install -g dotnet-format
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: lint
         run: |

--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up .NET 9
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9
       - name: Check .NET version

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -32,10 +32,10 @@ jobs:
           PASSWORD: ${{ secrets.PASSWORD }}
           ENDPOINT: ${{ secrets.ENDPOINT }}
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v6
 
           - name: .NET Core 8
-            uses: actions/setup-dotnet@v3
+            uses: actions/setup-dotnet@v5
             with:
               dotnet-version: |
                 6
@@ -75,7 +75,7 @@ jobs:
               echo "${{secrets.REDIS_USER_PRIVATE_KEY}}" > tests/NRedisStack.Tests/bin/Debug/${{inputs.clr_version}}/redis_user_private.key
               dotnet test -f ${{inputs.clr_version}} --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover -p:BuildInParallel=false tests/Test.proj --logger GitHubActions
           - name: Codecov
-            uses: codecov/codecov-action@v3
+            uses: codecov/codecov-action@v6
             with:
               token: ${{secrets.CODECOV_TOKEN}}
               verbose: true

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check Spelling
         uses: rojopolis/spellcheck-github-actions@0.35.0
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # First step: Handle regular issues (excluding needs-information)
       - name: Mark regular issues as stale
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Default stale policy
@@ -50,7 +50,7 @@ jobs:
           exempt-pr-labels: 'no-stale'
       # Second step: Handle waiting-for-feedback issues with accelerated timeline
       - name: Mark waiting-for-feedback issues as stale
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Accelerated timeline for waiting-for-feedback


### PR DESCRIPTION
Preparation for Node.js v20 deprecation on GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only workflow action version pins change; no application or release logic is modified, though CI behavior could shift if a major action release changes defaults.
> 
> **Overview**
> Bumps pinned **GitHub Actions** across CI workflows so runners stay on supported action runtimes (aligned with **Node.js 20** on Actions).
> 
> **`actions/checkout`** moves from **v3** to **v6** in linter, NuGet release, reusable build/test, and spellcheck workflows. **`actions/setup-dotnet`** goes from **v3** to **v5** in NuGet release and reusable workflows. **`codecov/codecov-action`** is **v3** → **v6** in the reusable workflow. **`release-drafter/release-drafter`** is **v5** → **v6**. **`actions/stale`** is **v9** → **v10** in both stale-management steps. Workflow logic and job configuration are unchanged aside from these version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb6436e9a0a941c3554fabfccde817311b8e5a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->