### PR TITLE
Fix CI - updated FT.INFO changes vector_index_sz_mb

### DIFF
--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -891,7 +891,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
             Assert.Equal(102, info.NumTerms);
             Assert.True(info.NumRecords >= 200);
             Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            Assert.Equal(0, info.VectorIndexSzMebibytes);
+            log.WriteLine($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
             Assert.Equal(208, info.TotalInvertedIndexBlocks);
             Assert.True(info.OffsetVectorsSzMebibytes < 1);
             Assert.True(info.DocTableSizeMebibytes < 1);
@@ -979,7 +979,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
             Assert.Equal(102, info.NumTerms);
             Assert.True(info.NumRecords >= 200);
             Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            Assert.Equal(0, info.VectorIndexSzMebibytes);
+            log.WriteLine($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
             Assert.Equal(208, info.TotalInvertedIndexBlocks);
             Assert.True(info.OffsetVectorsSzMebibytes < 1);
             Assert.True(info.DocTableSizeMebibytes < 1);
@@ -1057,7 +1057,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
             Assert.Equal(102, info.NumTerms);
             Assert.True(info.NumRecords >= 200);
             Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            Assert.Equal(0, info.VectorIndexSzMebibytes);
+            log.WriteLine($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
             Assert.Equal(208, info.TotalInvertedIndexBlocks);
             Assert.True(info.OffsetVectorsSzMebibytes < 1);
             Assert.True(info.DocTableSizeMebibytes < 1);
@@ -1169,7 +1169,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
             Assert.Equal(102, info.NumTerms);
             Assert.True(info.NumRecords >= 200);
             Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            Assert.Equal(0, info.VectorIndexSzMebibytes);
+            log.WriteLine($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
             Assert.Equal(208, info.TotalInvertedIndexBlocks);
             Assert.True(info.OffsetVectorsSzMebibytes < 1);
             Assert.True(info.DocTableSizeMebibytes < 1);


### PR DESCRIPTION
This value is no longer zero, so the test expectation changes; to avoid version hell, just log for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only relaxation of a version-sensitive assertion; no production code or API behavior changes.
> 
> **Overview**
> Fixes CI failures after **FT.INFO** started reporting non-zero **`vector_index_sz_mb`** (mapped to **`VectorIndexSzMebibytes`**).
> 
> In four standalone **`FT.INFO`** assertion blocks inside **`SearchTests`** (Alter/AlterAdd sync and async paths), the hard **`Assert.Equal(0, info.VectorIndexSzMebibytes)`** is removed and replaced with **`log.WriteLine`** so the value is visible in test output without pinning it to a specific Redis/RediSearch version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92b552c3d2897b4d87d386fa6bdf4a1a2b859da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->