### PR TITLE
Update StackExchange.Redis version to 3.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <!-- primary library -->
     <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.0.0" />
     <!-- tests, etc -->
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/tests/NRedisStack.Tests/EndpointsFixture.cs
+++ b/tests/NRedisStack.Tests/EndpointsFixture.cs
@@ -128,6 +128,7 @@ public class EndpointsFixture : IDisposable
         {
             var options = configurationOptions.Clone(); // isolate before we start applying the protocol
             options.Protocol = protocol.IsResp3() ? RedisProtocol.Resp3 : RedisProtocol.Resp2;
+            options.AllowAdmin = true; // from 3.0, Execute[Async] does a better job of recognizing admin commands
             options.HighIntegrity = protocol.IsHighIntegrity();
             options.ConnectTimeout = 2000;
             if (shareConnection) options.AbortOnConnectFail = false;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> A major-version bump of the core Redis client can affect connection, protocol, and command behavior across the library and tests; scope is limited to the version pin plus a targeted test connection option.
> 
> **Overview**
> **Bumps the central `StackExchange.Redis` package reference from 2.13.17 to 3.0.0** in `Directory.Packages.props`, so the whole solution picks up the 3.x client.
> 
> Test infrastructure is adjusted for 3.0 behavior: **`EndpointsFixture` now sets `AllowAdmin = true`** on cloned `ConfigurationOptions` when opening shared endpoint connections, with a note that `Execute` / `ExecuteAsync` handle admin commands more reliably in 3.0. That aligns fixture-created connections with tests that already rely on admin-style commands (e.g. `FLUSHALL` via `Execute` in `AbstractNRedisStackTest`).
> 
> Cosmetic **newline-at-EOF** fixes only in the touched files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ef036aa0c671e9894aa099bc7b3cc9992f70584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->