### PR TITLE
Investigate #508 - FT.SEARCH not applying offset

### DIFF
--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -124,7 +124,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
         // is the command we build correct? assert the exact wire command.
         var command = SearchCommandBuilder.Search(index, query);
-        log.WriteLine($"resp3={isResp3}; command: {command.Command} {string.Join(" ", command.Args)}");
+        Log($"resp3={isResp3}; command: {command.Command} {string.Join(" ", command.Args)}");
         Assert.Equal("FT.SEARCH", command.Command);
         var expectedArgs = new object[] { index, "*", "SORTBY", "count", "ASC", "LIMIT", 20, 10 };
         Assert.Equal(expectedArgs.Length, command.Args.Length);
@@ -135,15 +135,15 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
         // run that exact command manually and inspect the raw reply from the wire.
         var raw = db.Execute(command);
-        log.WriteLine($"raw reply: Resp2Type={raw.Resp2Type}, Resp3Type={raw.Resp3Type}, Length={raw.Length}");
+        Log($"raw reply: Resp2Type={raw.Resp2Type}, Resp3Type={raw.Resp3Type}, Length={raw.Length}");
         int rawDocCount = CountRawSearchDocs(raw, out long rawTotal);
-        log.WriteLine($"raw total_results={rawTotal}, raw document count={rawDocCount}");
+        Log($"raw total_results={rawTotal}, raw document count={rawDocCount}");
         Assert.Equal(total, rawTotal);
         Assert.Equal(10, rawDocCount);
 
         // use the library API
         var results = ft.Search(index, query);
-        log.WriteLine($"typed TotalResults={results.TotalResults}, typed Documents.Count={results.Documents.Count}");
+        Log($"typed TotalResults={results.TotalResults}, typed Documents.Count={results.Documents.Count}");
         Assert.Equal(total, results.TotalResults);
         Assert.Equal(10, results.Documents.Count);
     }
@@ -973,7 +973,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
             Assert.Equal(102, info.NumTerms);
             Assert.True(info.NumRecords >= 200);
             Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            log.WriteLine($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
+            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
             Assert.Equal(208, info.TotalInvertedIndexBlocks);
             Assert.True(info.OffsetVectorsSzMebibytes < 1);
             Assert.True(info.DocTableSizeMebibytes < 1);
@@ -1061,7 +1061,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
             Assert.Equal(102, info.NumTerms);
             Assert.True(info.NumRecords >= 200);
             Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            log.WriteLine($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
+            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
             Assert.Equal(208, info.TotalInvertedIndexBlocks);
             Assert.True(info.OffsetVectorsSzMebibytes < 1);
             Assert.True(info.DocTableSizeMebibytes < 1);
@@ -1139,7 +1139,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
             Assert.Equal(102, info.NumTerms);
             Assert.True(info.NumRecords >= 200);
             Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            log.WriteLine($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
+            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
             Assert.Equal(208, info.TotalInvertedIndexBlocks);
             Assert.True(info.OffsetVectorsSzMebibytes < 1);
             Assert.True(info.DocTableSizeMebibytes < 1);
@@ -1251,7 +1251,7 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
             Assert.Equal(102, info.NumTerms);
             Assert.True(info.NumRecords >= 200);
             Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            log.WriteLine($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
+            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
             Assert.Equal(208, info.TotalInvertedIndexBlocks);
             Assert.True(info.OffsetVectorsSzMebibytes < 1);
             Assert.True(info.DocTableSizeMebibytes < 1);

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -98,6 +98,34 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
         Assert.Equal(expected, indexed);
     }
 
+    [Theory]
+    [MemberData(nameof(EndpointsFixture.Env.AllEnvironments), MemberType = typeof(EndpointsFixture.Env))]
+    public void TestSearchLimitOffset(string endpointId)
+    {
+        // Regression test for Query.Limit(offset, count): the number of returned documents
+        // should equal 'count', regardless of RESP2/RESP3 (these run as separate test cases).
+        SkipClusterPre8(endpointId);
+        IDatabase db = GetCleanDatabase(endpointId);
+        var ft = db.FT();
+        Schema sc = new();
+        sc.AddNumericField("count", sortable: true);
+        ft.Create(index, FTCreateParams.CreateParams(), sc);
+
+        const int total = 30;
+        for (int i = 0; i < total; i++)
+        {
+            AddDocument(db, new Document($"data{i:D2}").Set("count", i));
+        }
+
+        AssertIndexSize(ft, index, total);
+
+        var query = new Query("*").SetNoContent(false).SetSortBy("count", ascending: true).Limit(20, 10);
+        var results = ft.Search(index, query);
+
+        Assert.Equal(total, results.TotalResults);
+        Assert.Equal(10, results.Documents.Count);
+    }
+
     [SkipIfRedisTheory(Is.Enterprise)]
     [MemberData(nameof(EndpointsFixture.Env.AllEnvironments), MemberType = typeof(EndpointsFixture.Env))]
     public void TestAggregationRequestVerbatim(string endpointId)

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -119,11 +119,65 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
         AssertIndexSize(ft, index, total);
 
+        bool isResp3 = TestContext.Current.GetRunProtocol().IsResp3();
         var query = new Query("*").SetNoContent(false).SetSortBy("count", ascending: true).Limit(20, 10);
-        var results = ft.Search(index, query);
 
+        // is the command we build correct? assert the exact wire command.
+        var command = SearchCommandBuilder.Search(index, query);
+        log.WriteLine($"resp3={isResp3}; command: {command.Command} {string.Join(" ", command.Args)}");
+        Assert.Equal("FT.SEARCH", command.Command);
+        var expectedArgs = new object[] { index, "*", "SORTBY", "count", "ASC", "LIMIT", 20, 10 };
+        Assert.Equal(expectedArgs.Length, command.Args.Length);
+        for (int i = 0; i < expectedArgs.Length; i++)
+        {
+            Assert.Equal(expectedArgs[i].ToString(), command.Args[i].ToString());
+        }
+
+        // run that exact command manually and inspect the raw reply from the wire.
+        var raw = db.Execute(command);
+        log.WriteLine($"raw reply: Resp2Type={raw.Resp2Type}, Resp3Type={raw.Resp3Type}, Length={raw.Length}");
+        int rawDocCount = CountRawSearchDocs(raw, out long rawTotal);
+        log.WriteLine($"raw total_results={rawTotal}, raw document count={rawDocCount}");
+        Assert.Equal(total, rawTotal);
+        Assert.Equal(10, rawDocCount);
+
+        // use the library API
+        var results = ft.Search(index, query);
+        log.WriteLine($"typed TotalResults={results.TotalResults}, typed Documents.Count={results.Documents.Count}");
         Assert.Equal(total, results.TotalResults);
         Assert.Equal(10, results.Documents.Count);
+    }
+
+    // Counts the documents in a raw FT.SEARCH reply. Layout is decided by the *actual* reply shape
+    // (the same thing SearchResult branches on), not by the connection protocol: an older server can
+    // reply with a flat array even on a RESP3 connection, and that mismatch is exactly what we want to see.
+    //   RESP3 map:  { attributes, format, results: [...], total_results, warning }
+    //   RESP2 array: [total, id, fields, id, fields, ...]
+    private static int CountRawSearchDocs(RedisResult raw, out long totalResults)
+    {
+        totalResults = -1;
+        var arr = (RedisResult[])raw!;
+        if (raw.Resp3Type is ResultType.Map)
+        {
+            int count = -1;
+            for (int i = 0; i + 1 < arr.Length; i += 2)
+            {
+                switch (arr[i].ToString())
+                {
+                    case "results":
+                        count = arr[i + 1].Length;
+                        break;
+                    case "total_results":
+                        totalResults = (long)arr[i + 1];
+                        break;
+                }
+            }
+            return count;
+        }
+
+        // RESP2: first element is the total; remaining elements are (id, fields) pairs (content, no scores/payloads).
+        totalResults = (long)arr[0];
+        return (arr.Length - 1) / 2;
     }
 
     [SkipIfRedisTheory(Is.Enterprise)]

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -102,9 +102,15 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     [MemberData(nameof(EndpointsFixture.Env.AllEnvironments), MemberType = typeof(EndpointsFixture.Env))]
     public void TestSearchLimitOffset(string endpointId)
     {
-        // Regression test for Query.Limit(offset, count): the number of returned documents
-        // should equal 'count', regardless of RESP2/RESP3 (these run as separate test cases).
         SkipClusterPre8(endpointId);
+
+        // Cluster + RESP3 ignores the LIMIT offset server-side: FT.SEARCH returns the window
+        // [0, offset+count) instead of [offset, offset+count). This is a RediSearch module bug,
+        // not a client bug (the raw wire reply already contains the wrong documents); skip until fixed.
+        // https://github.com/RediSearch/RediSearch/issues/10369
+        Assert.SkipWhen(endpointId == EndpointsFixture.Env.Cluster && TestContext.Current.GetRunProtocol().IsResp3(),
+            "RediSearch#10369: FT.SEARCH on cluster+RESP3 ignores the LIMIT offset");
+
         IDatabase db = GetCleanDatabase(endpointId);
         var ft = db.FT();
         Schema sc = new();
@@ -119,65 +125,11 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
 
         AssertIndexSize(ft, index, total);
 
-        bool isResp3 = TestContext.Current.GetRunProtocol().IsResp3();
         var query = new Query("*").SetNoContent(false).SetSortBy("count", ascending: true).Limit(20, 10);
-
-        // is the command we build correct? assert the exact wire command.
-        var command = SearchCommandBuilder.Search(index, query);
-        Log($"resp3={isResp3}; command: {command.Command} {string.Join(" ", command.Args)}");
-        Assert.Equal("FT.SEARCH", command.Command);
-        var expectedArgs = new object[] { index, "*", "SORTBY", "count", "ASC", "LIMIT", 20, 10 };
-        Assert.Equal(expectedArgs.Length, command.Args.Length);
-        for (int i = 0; i < expectedArgs.Length; i++)
-        {
-            Assert.Equal(expectedArgs[i].ToString(), command.Args[i].ToString());
-        }
-
-        // run that exact command manually and inspect the raw reply from the wire.
-        var raw = db.Execute(command);
-        Log($"raw reply: Resp2Type={raw.Resp2Type}, Resp3Type={raw.Resp3Type}, Length={raw.Length}");
-        int rawDocCount = CountRawSearchDocs(raw, out long rawTotal);
-        Log($"raw total_results={rawTotal}, raw document count={rawDocCount}");
-        Assert.Equal(total, rawTotal);
-        Assert.Equal(10, rawDocCount);
-
-        // use the library API
         var results = ft.Search(index, query);
-        Log($"typed TotalResults={results.TotalResults}, typed Documents.Count={results.Documents.Count}");
+
         Assert.Equal(total, results.TotalResults);
         Assert.Equal(10, results.Documents.Count);
-    }
-
-    // Counts the documents in a raw FT.SEARCH reply. Layout is decided by the *actual* reply shape
-    // (the same thing SearchResult branches on), not by the connection protocol: an older server can
-    // reply with a flat array even on a RESP3 connection, and that mismatch is exactly what we want to see.
-    //   RESP3 map:  { attributes, format, results: [...], total_results, warning }
-    //   RESP2 array: [total, id, fields, id, fields, ...]
-    private static int CountRawSearchDocs(RedisResult raw, out long totalResults)
-    {
-        totalResults = -1;
-        var arr = (RedisResult[])raw!;
-        if (raw.Resp3Type is ResultType.Map)
-        {
-            int count = -1;
-            for (int i = 0; i + 1 < arr.Length; i += 2)
-            {
-                switch (arr[i].ToString())
-                {
-                    case "results":
-                        count = arr[i + 1].Length;
-                        break;
-                    case "total_results":
-                        totalResults = (long)arr[i + 1];
-                        break;
-                }
-            }
-            return count;
-        }
-
-        // RESP2: first element is the total; remaining elements are (id, fields) pairs (content, no scores/payloads).
-        totalResults = (long)arr[0];
-        return (arr.Length - 1) / 2;
     }
 
     [SkipIfRedisTheory(Is.Enterprise)]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes with no production library modifications; CI may skip one environment combination until the upstream RediSearch bug is fixed.
> 
> **Overview**
> Adds **`TestSearchLimitOffset`** to exercise `FT.SEARCH` with `Query.Limit(20, 10)` (offset 20, count 10) on a sorted numeric index and assert **30 total hits** with **10 documents** returned, tied to investigating **#508**.
> 
> The test runs across **`EndpointsFixture.Env.AllEnvironments`**, applies existing **`SkipClusterPre8`**, and **skips cluster + RESP3** when RediSearch ignores the LIMIT offset (documented as **RediSearch#10369**, server-side—not the client).
> 
> Also replaces **`log.WriteLine`** with the base **`Log(...)`** helper in several Alter index info diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec19736be87e3f34c945b52f9f9472829ccc68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->