### PR TITLE
ci: run full Redis version matrix only nightly

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,11 @@ jobs:
         max-parallel: 15
         fail-fast: false
         matrix:
-          redis-version: [ '8.8', '8.6', '8.4', '8.2', '7.4', '7.2', '6.2']
+          # Full version set runs only on the nightly schedule; PRs and pushes
+          # test a reduced set (7.2 LTS, 7.4 LTS, 8.2 LTS, 8.8 current stable, 8.10 - next) to keep CI fast.
+          redis-version: ${{ fromJSON(github.event_name == 'schedule'
+            && '["8.10", "8.8", "8.6", "8.4", "8.2", "7.4", "7.2", "6.2"]'
+            || '["8.10", "8.8", "8.2", "7.4", "7.2"]') }}
           dotnet-version: ['8.0', '9.0', '10.0']
       name: Redis ${{ matrix.redis-version }}; .NET ${{ matrix.dotnet-version }};
       steps:

--- a/tests/dockers/.env.v8.10
+++ b/tests/dockers/.env.v8.10
@@ -1,0 +1,5 @@
+# Environment variables for Redis 8.10
+# Used by the run-tests GitHub Action
+
+# Redis CE image version (Redis 8+ includes modules natively)
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:custom-28772936538-debian


### PR DESCRIPTION
PRs and pushes now test a reduced set of LTS+current+next (7.2, 7.4, 8.2, 8.8, 8.10); the STS versions (8.4, 8.6) and, soon, the EOL version 6.2 run only on the nightly schedule to keep PR CI fast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and test docker config changes with no application runtime impact; tradeoff is slightly less Redis coverage on PRs until nightly runs.
> 
> **Overview**
> **Integration CI** now picks the Redis matrix from the workflow trigger: **nightly `schedule`** still runs the full set (8.10 through 6.2, including STS **8.4** and **8.6**); **PRs and pushes** run a smaller set (**8.10**, **8.8**, **8.2**, **7.4**, **7.2**) to cut job count and keep feedback fast.
> 
> Adds **`tests/dockers/.env.v8.10`** so the shared **run-tests** action can spin up **Redis 8.10** via the `client-libs-test` image pin used in the matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f092e7c85b16a2d51b59210e2a4c6023ad77d27e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->