### PR TITLE
Upload Redis logs in CI

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -140,6 +140,16 @@ runs:
         fi
         dotnet test -f ${CLR_VERSION} --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover -p:BuildInParallel=false tests/Test.proj --logger GitHubActions
         echo "::endgroup::"
+    - name: Upload Redis logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: redis-logs-${{ inputs.redis-version || inputs.client-libs-test-image-tag }}-dotnet${{ inputs.dotnet-version }}
+        path: |
+          tests/dockers/cluster/node-*/redis.log
+          tests/dockers/cluster/node-*/nodes.conf
+          tests/dockers/standalone/node-*/redis.log
+        if-no-files-found: warn
     - name: Codecov
       if: inputs.upload-coverage != 'false'
       uses: codecov/codecov-action@v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change with no impact on application runtime or test logic.
> 
> **Overview**
> **CI debugging:** The composite `run-tests` action now uploads Redis container diagnostics after the test step, using `if: always()` so logs are captured even when tests fail.
> 
> Artifacts are named per matrix inputs (`redis-version` or `client-libs-test-image-tag`, plus `dotnet-version`) and include `redis.log` and cluster `nodes.conf` under `tests/dockers/cluster/node-*` and `tests/dockers/standalone/node-*`, with `if-no-files-found: warn` when paths are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449b6d24975a6e79d282aa167048de239ad75b4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->