### PR TITLE
Stabilize CI

### DIFF
--- a/tests/Doc/QueryEmExample.cs
+++ b/tests/Doc/QueryEmExample.cs
@@ -210,6 +210,13 @@ public class QueryEmExample
         }
         // HIDE_END
 
+        // REMOVE_START
+        // JSON indexing is asynchronous; wait for the background indexer to catch
+        // up before querying, otherwise searches can intermittently return fewer
+        // results than expected (especially under CI load). Removed from docs.
+        Thread.Sleep(2000);
+        // REMOVE_END
+
 
         // STEP_START em1
         SearchResult res1 = db.FT().Search(
@@ -259,6 +266,10 @@ public class QueryEmExample
         db.FT().Create("idx:email", emailParams, emailSchema);
 
         db.JSON().Set("key:1", "$", "{\"email\": \"test@redis.com\"}");
+
+        // REMOVE_START
+        Thread.Sleep(2000); // wait for async indexing (removed from docs)
+        // REMOVE_END
 
 
         SearchResult res4 = db.FT().Search(

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -894,27 +894,30 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
         {
             Assert.Equal(100, info.NumDocs);
 
-            // these numbers don't make sense when considering a shard
-            Assert.NotNull(info.MaxDocId);
-            Assert.Equal(102, info.NumTerms);
-            Assert.True(info.NumRecords >= 200);
-            Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
-            Assert.Equal(208, info.TotalInvertedIndexBlocks);
-            Assert.True(info.OffsetVectorsSzMebibytes < 1);
-            Assert.True(info.DocTableSizeMebibytes < 1);
-            Assert.Equal(0, info.SortableValueSizeMebibytes);
-            Assert.True(info.KeyTableSizeMebibytes < 1);
-            Assert.Equal(8, (int)info.RecordsPerDocAvg);
-            Assert.True(info.BytesPerRecordAvg > 5);
-            Assert.True(info.OffsetsPerTermAvg > 0.8);
-            Assert.Equal(8, info.OffsetBitsPerRecordAvg);
+            // These are internal index statistics whose exact values drift with the
+            // RediSearch version and background GC timing; log them rather than assert.
+            Log($"{nameof(info.MaxDocId)}: {info.MaxDocId}");
+            Log($"{nameof(info.NumTerms)}: {info.NumTerms}");
+            Log($"{nameof(info.NumRecords)}: {info.NumRecords}");
+            Log($"{nameof(info.InvertedSzMebibytes)}: {info.InvertedSzMebibytes}");
+            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}");
+            Log($"{nameof(info.TotalInvertedIndexBlocks)}: {info.TotalInvertedIndexBlocks}");
+            Log($"{nameof(info.OffsetVectorsSzMebibytes)}: {info.OffsetVectorsSzMebibytes}");
+            Log($"{nameof(info.DocTableSizeMebibytes)}: {info.DocTableSizeMebibytes}");
+            Log($"{nameof(info.SortableValueSizeMebibytes)}: {info.SortableValueSizeMebibytes}");
+            Log($"{nameof(info.KeyTableSizeMebibytes)}: {info.KeyTableSizeMebibytes}");
+            Log($"{nameof(info.RecordsPerDocAvg)}: {info.RecordsPerDocAvg}");
+            Log($"{nameof(info.BytesPerRecordAvg)}: {info.BytesPerRecordAvg}");
+            Log($"{nameof(info.OffsetsPerTermAvg)}: {info.OffsetsPerTermAvg}");
+            Log($"{nameof(info.OffsetBitsPerRecordAvg)}: {info.OffsetBitsPerRecordAvg}");
+            Log($"{nameof(info.NumberOfUses)}: {info.NumberOfUses}");
+            Log($"{nameof(info.GcStats)}.Count: {info.GcStats.Count}");
+            Log($"{nameof(info.CursorStats)}.Count: {info.CursorStats.Count}");
+
+            // Correctness: everything was indexed, with no failures.
             Assert.Equal(0, info.HashIndexingFailures);
             Assert.Equal(0, info.Indexing);
             Assert.Equal(1, info.PercentIndexed);
-            Assert.Equal(5, info.NumberOfUses);
-            Assert.Equal(7, info.GcStats.Count);
-            Assert.Equal(4, info.CursorStats.Count);
         }
     }
 
@@ -982,27 +985,30 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
         {
             Assert.Equal(100, info.NumDocs);
 
-            // these numbers don't make sense when considering a shard
-            Assert.Equal("300", info.MaxDocId);
-            Assert.Equal(102, info.NumTerms);
-            Assert.True(info.NumRecords >= 200);
-            Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
-            Assert.Equal(208, info.TotalInvertedIndexBlocks);
-            Assert.True(info.OffsetVectorsSzMebibytes < 1);
-            Assert.True(info.DocTableSizeMebibytes < 1);
-            Assert.Equal(0, info.SortableValueSizeMebibytes);
-            Assert.True(info.KeyTableSizeMebibytes < 1);
-            Assert.Equal(8, (int)info.RecordsPerDocAvg);
-            Assert.True(info.BytesPerRecordAvg > 5);
-            Assert.True(info.OffsetsPerTermAvg > 0.8);
-            Assert.Equal(8, info.OffsetBitsPerRecordAvg);
+            // These are internal index statistics whose exact values drift with the
+            // RediSearch version and background GC timing; log them rather than assert.
+            Log($"{nameof(info.MaxDocId)}: {info.MaxDocId}");
+            Log($"{nameof(info.NumTerms)}: {info.NumTerms}");
+            Log($"{nameof(info.NumRecords)}: {info.NumRecords}");
+            Log($"{nameof(info.InvertedSzMebibytes)}: {info.InvertedSzMebibytes}");
+            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}");
+            Log($"{nameof(info.TotalInvertedIndexBlocks)}: {info.TotalInvertedIndexBlocks}");
+            Log($"{nameof(info.OffsetVectorsSzMebibytes)}: {info.OffsetVectorsSzMebibytes}");
+            Log($"{nameof(info.DocTableSizeMebibytes)}: {info.DocTableSizeMebibytes}");
+            Log($"{nameof(info.SortableValueSizeMebibytes)}: {info.SortableValueSizeMebibytes}");
+            Log($"{nameof(info.KeyTableSizeMebibytes)}: {info.KeyTableSizeMebibytes}");
+            Log($"{nameof(info.RecordsPerDocAvg)}: {info.RecordsPerDocAvg}");
+            Log($"{nameof(info.BytesPerRecordAvg)}: {info.BytesPerRecordAvg}");
+            Log($"{nameof(info.OffsetsPerTermAvg)}: {info.OffsetsPerTermAvg}");
+            Log($"{nameof(info.OffsetBitsPerRecordAvg)}: {info.OffsetBitsPerRecordAvg}");
+            Log($"{nameof(info.NumberOfUses)}: {info.NumberOfUses}");
+            Log($"{nameof(info.GcStats)}.Count: {info.GcStats.Count}");
+            Log($"{nameof(info.CursorStats)}.Count: {info.CursorStats.Count}");
+
+            // Correctness: everything was indexed, with no failures.
             Assert.Equal(0, info.HashIndexingFailures);
             Assert.Equal(0, info.Indexing);
             Assert.Equal(1, info.PercentIndexed);
-            Assert.Equal(5, info.NumberOfUses);
-            Assert.Equal(7, info.GcStats.Count);
-            Assert.Equal(4, info.CursorStats.Count);
         }
     }
 

--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -1060,27 +1060,30 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
         {
             Assert.Equal(100, info.NumDocs);
 
-            // these numbers don't make sense when considering a shard
-            Assert.NotNull(info.MaxDocId);
-            Assert.Equal(102, info.NumTerms);
-            Assert.True(info.NumRecords >= 200);
-            Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
-            Assert.Equal(208, info.TotalInvertedIndexBlocks);
-            Assert.True(info.OffsetVectorsSzMebibytes < 1);
-            Assert.True(info.DocTableSizeMebibytes < 1);
-            Assert.Equal(0, info.SortableValueSizeMebibytes);
-            Assert.True(info.KeyTableSizeMebibytes < 1);
-            Assert.Equal(8, (int)info.RecordsPerDocAvg);
-            Assert.True(info.BytesPerRecordAvg > 5);
-            Assert.True(info.OffsetsPerTermAvg > 0.8);
-            Assert.Equal(8, info.OffsetBitsPerRecordAvg);
+            // These are internal index statistics whose exact values drift with the
+            // RediSearch version and background GC timing; log them rather than assert.
+            Log($"{nameof(info.MaxDocId)}: {info.MaxDocId}");
+            Log($"{nameof(info.NumTerms)}: {info.NumTerms}");
+            Log($"{nameof(info.NumRecords)}: {info.NumRecords}");
+            Log($"{nameof(info.InvertedSzMebibytes)}: {info.InvertedSzMebibytes}");
+            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}");
+            Log($"{nameof(info.TotalInvertedIndexBlocks)}: {info.TotalInvertedIndexBlocks}");
+            Log($"{nameof(info.OffsetVectorsSzMebibytes)}: {info.OffsetVectorsSzMebibytes}");
+            Log($"{nameof(info.DocTableSizeMebibytes)}: {info.DocTableSizeMebibytes}");
+            Log($"{nameof(info.SortableValueSizeMebibytes)}: {info.SortableValueSizeMebibytes}");
+            Log($"{nameof(info.KeyTableSizeMebibytes)}: {info.KeyTableSizeMebibytes}");
+            Log($"{nameof(info.RecordsPerDocAvg)}: {info.RecordsPerDocAvg}");
+            Log($"{nameof(info.BytesPerRecordAvg)}: {info.BytesPerRecordAvg}");
+            Log($"{nameof(info.OffsetsPerTermAvg)}: {info.OffsetsPerTermAvg}");
+            Log($"{nameof(info.OffsetBitsPerRecordAvg)}: {info.OffsetBitsPerRecordAvg}");
+            Log($"{nameof(info.NumberOfUses)}: {info.NumberOfUses}");
+            Log($"{nameof(info.GcStats)}.Count: {info.GcStats.Count}");
+            Log($"{nameof(info.CursorStats)}.Count: {info.CursorStats.Count}");
+
+            // Correctness: everything was indexed, with no failures.
             Assert.Equal(0, info.HashIndexingFailures);
             Assert.Equal(0, info.Indexing);
             Assert.Equal(1, info.PercentIndexed);
-            Assert.Equal(4, info.NumberOfUses);
-            Assert.Equal(7, info.GcStats.Count);
-            Assert.Equal(4, info.CursorStats.Count);
         }
     }
 
@@ -1172,27 +1175,30 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
         {
             Assert.Equal(100, info.NumDocs);
 
-            // these numbers don't make sense when considering a shard
-            Assert.Equal("300", info.MaxDocId);
-            Assert.Equal(102, info.NumTerms);
-            Assert.True(info.NumRecords >= 200);
-            Assert.True(info.InvertedSzMebibytes < 1); // TODO: check this line and all the <1 lines
-            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}"); // version-dependent
-            Assert.Equal(208, info.TotalInvertedIndexBlocks);
-            Assert.True(info.OffsetVectorsSzMebibytes < 1);
-            Assert.True(info.DocTableSizeMebibytes < 1);
-            Assert.Equal(0, info.SortableValueSizeMebibytes);
-            Assert.True(info.KeyTableSizeMebibytes < 1);
-            Assert.Equal(8, (int)info.RecordsPerDocAvg);
-            Assert.True(info.BytesPerRecordAvg > 5);
-            Assert.True(info.OffsetsPerTermAvg > 0.8);
-            Assert.Equal(8, info.OffsetBitsPerRecordAvg);
+            // These are internal index statistics whose exact values drift with the
+            // RediSearch version and background GC timing; log them rather than assert.
+            Log($"{nameof(info.MaxDocId)}: {info.MaxDocId}");
+            Log($"{nameof(info.NumTerms)}: {info.NumTerms}");
+            Log($"{nameof(info.NumRecords)}: {info.NumRecords}");
+            Log($"{nameof(info.InvertedSzMebibytes)}: {info.InvertedSzMebibytes}");
+            Log($"{nameof(info.VectorIndexSzMebibytes)}: {info.VectorIndexSzMebibytes}");
+            Log($"{nameof(info.TotalInvertedIndexBlocks)}: {info.TotalInvertedIndexBlocks}");
+            Log($"{nameof(info.OffsetVectorsSzMebibytes)}: {info.OffsetVectorsSzMebibytes}");
+            Log($"{nameof(info.DocTableSizeMebibytes)}: {info.DocTableSizeMebibytes}");
+            Log($"{nameof(info.SortableValueSizeMebibytes)}: {info.SortableValueSizeMebibytes}");
+            Log($"{nameof(info.KeyTableSizeMebibytes)}: {info.KeyTableSizeMebibytes}");
+            Log($"{nameof(info.RecordsPerDocAvg)}: {info.RecordsPerDocAvg}");
+            Log($"{nameof(info.BytesPerRecordAvg)}: {info.BytesPerRecordAvg}");
+            Log($"{nameof(info.OffsetsPerTermAvg)}: {info.OffsetsPerTermAvg}");
+            Log($"{nameof(info.OffsetBitsPerRecordAvg)}: {info.OffsetBitsPerRecordAvg}");
+            Log($"{nameof(info.NumberOfUses)}: {info.NumberOfUses}");
+            Log($"{nameof(info.GcStats)}.Count: {info.GcStats.Count}");
+            Log($"{nameof(info.CursorStats)}.Count: {info.CursorStats.Count}");
+
+            // Correctness: everything was indexed, with no failures.
             Assert.Equal(0, info.HashIndexingFailures);
             Assert.Equal(0, info.Indexing);
             Assert.Equal(1, info.PercentIndexed);
-            Assert.Equal(4, info.NumberOfUses);
-            Assert.Equal(7, info.GcStats.Count);
-            Assert.Equal(4, info.CursorStats.Count);
         }
     }
 

--- a/tests/dockers/docker-compose.yml
+++ b/tests/dockers/docker-compose.yml
@@ -16,6 +16,13 @@ services:
       - 6666:6666 # TLS port
     volumes:
       - "./standalone:/redis/work"
+    healthcheck:
+      # gate `up --wait` on the server actually accepting commands
+      test: ["CMD-SHELL", "redis-cli -p 6379 PING | grep -q PONG"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      start_period: 1s
     profiles:
       - standalone
       - all
@@ -36,6 +43,16 @@ services:
       - "27379-27384:27379-27384"
     volumes:
       - "./cluster:/redis/work"
+    healthcheck:
+      # gate `up --wait` on the cluster being fully formed (all 16384 slots
+      # assigned). Without this the container reports "running" while
+      # redis-cli --cluster create is still assigning slots, so tests connect
+      # to a half-formed cluster and cache a stale slot map -> spurious -MOVED.
+      test: ["CMD-SHELL", "redis-cli -p 16379 CLUSTER INFO | grep -q cluster_state:ok"]
+      interval: 1s
+      timeout: 5s
+      retries: 60
+      start_period: 2s
     profiles:
       - cluster
       - all


### PR DESCRIPTION
1. ensure we have healthchecks so `up --wait` works correctly and we don't (as a race condition) start against an incomplete cluster
2. don't assert `FT.INFO` internal metrics - just log them; they drift too much between module versions and are dependent on GC timing
3. add indexing pause in `QueryEmExample`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI infrastructure only; no production library or runtime behavior changes.
> 
> **Overview**
> Reduces flaky CI by fixing **when** tests start against Redis and **what** they assert after search indexing.
> 
> **Docker Compose** adds healthchecks on standalone (`PING`) and cluster (`cluster_state:ok`) so `docker compose up --wait` does not proceed until Redis accepts commands and the cluster has all slots assigned—avoiding races that produced spurious `-MOVED` from stale slot maps.
> 
> **Search tests** replace brittle `FT.INFO` internal statistic assertions (version- and GC-sensitive) with logging on standalone, while keeping correctness checks (`NumDocs`, `HashIndexingFailures`, `PercentIndexed`, etc.).
> 
> **Doc example** `QueryEmExample` inserts 2s sleeps (stripped from published docs) after JSON writes so async RediSearch indexing can catch up before `FT.SEARCH` assertions under load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ec7ed7e99dd2b09241f20145ee163ae4472c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->