### PR TITLE
chore: bump Redis 8.10 test image to custom-29557896054-debian

### DIFF
--- a/tests/dockers/.env.v8.10
+++ b/tests/dockers/.env.v8.10
@@ -2,4 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:custom-28772936538-debian
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:custom-29557896054-debian


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only dependency pin with no application or production code changes.
> 
> **Overview**
> Updates the Redis **8.10** CI test environment to use a newer `redislabs/client-libs-test` Debian image (`custom-29557896054-debian` instead of `custom-28772936538-debian`) via `tests/dockers/.env.v8.10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d074056bf6964a9252d5f5d385538d1c22ba2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->