### PR TITLE
test(search): skip TestSearchLimitOffset on RESP3 for standalone too

### DIFF
--- a/tests/NRedisStack.Tests/Search/SearchTests.cs
+++ b/tests/NRedisStack.Tests/Search/SearchTests.cs
@@ -78,12 +78,13 @@ public class SearchTests(EndpointsFixture endpointsFixture, ITestOutputHelper lo
     {
         SkipClusterPre8(endpointId);
 
-        // Cluster + RESP3 ignores the LIMIT offset server-side: FT.SEARCH returns the window
+        // RESP3 ignores the LIMIT offset server-side: FT.SEARCH returns the window
         // [0, offset+count) instead of [offset, offset+count). This is a RediSearch module bug,
-        // not a client bug (the raw wire reply already contains the wrong documents); skip until fixed.
+        // not a client bug (the raw wire reply already contains the wrong documents). It reproduces
+        // on both cluster and standalone Redis Enterprise databases, so skip both until fixed.
         // https://github.com/RediSearch/RediSearch/issues/10369
-        Assert.SkipWhen(endpointId == EndpointsFixture.Env.Cluster && TestContext.Current.GetRunProtocol().IsResp3(),
-            "RediSearch#10369: FT.SEARCH on cluster+RESP3 ignores the LIMIT offset");
+        Assert.SkipWhen(TestContext.Current.GetRunProtocol().IsResp3(),
+            "RediSearch#10369: FT.SEARCH on RESP3 ignores the LIMIT offset (cluster and standalone)");
 
         IDatabase db = GetCleanDatabase(endpointId);
         var ft = db.FT();


### PR DESCRIPTION
## Summary

`TestSearchLimitOffset` is affected by a known RediSearch LIMIT/offset behaviour
difference under RESP3 (RediSearch#10369). The test already skipped that case for
cluster, but the same RESP3 behaviour occurs on **standalone** as well, so the
test fails there when run with RESP3.

## What changed

- Broaden the existing skip so `TestSearchLimitOffset` is skipped on RESP3 for
  standalone in addition to cluster, until RediSearch#10369 is resolved.

Test-only change.

## Test plan

- [x] Search test suite on standalone with RESP2 (runs) and RESP3 (skips).

---
_Prepared with AI assistance and reviewed under my account._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production or client library behavior is modified.
> 
> **Overview**
> **`TestSearchLimitOffset`** is skipped on **any RESP3** run, not only cluster, because RediSearch#10369 (incorrect `FT.SEARCH` `LIMIT` offset) also shows up on standalone Redis Enterprise.
> 
> The skip condition drops the cluster check and only uses `TestContext.Current.GetRunProtocol().IsResp3()`, with comments and the skip message updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd31e6fd23ccc80c4854ecd52f0f6fb42bdcc997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->