### PR TITLE
chore: bump Redis 8.10 test image to 8.10-rc2

### DIFF
--- a/tests/dockers/.env.v8.10
+++ b/tests/dockers/.env.v8.10
@@ -2,4 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:custom-29557896054-debian
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.10-rc2


### PR DESCRIPTION
Updates the 8.10 test environment to the released `redislabs/client-libs-test:8.10-rc2` image (was pinned to custom build `custom-29557896054-debian`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Docker image pin with no production or client-library behavior changes.
> 
> **Overview**
> Updates **`tests/dockers/.env.v8.10`** so the run-tests GitHub Action pulls **`redislabs/client-libs-test:8.10-rc2`** instead of the one-off **`custom-29557896054-debian`** image.
> 
> This only changes which Redis CE test container runs for the 8.10 matrix job; no application or library code is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c216724ba0872d6b6e42594d5cbaab3b4bec98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->