### PR TITLE
stop dependabot trying to update GHATL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      # GHATL 3.x is built against Microsoft.Testing.Platform 2.0 (MTP v2), but
+      # our test stack (xunit.v3 3.x) is still on MTP v1 (pins MTP 1.9.1), so 3.x
+      # fails to build. Revisit once we move to xunit.v3 4.x / MTP v2.
+      - dependency-name: "GitHubActionsTestLogger"
+        versions: [">=3.0.0"]


### PR DESCRIPTION
Context #476, #479, #530

There is a hard dependency conflict here

What actually breaks (two layers):

1. GHATL 3.0 was rebuilt as a Microsoft.Testing.Platform (MTP) extension. Its MSBuild targets now inject a codegen hook (SelfRegisteredExtensions.cs) referencing the type GitHubActionsTestLogger.MtpIntegration. Our <IncludeAssets> for the package omits compile (fine for 2.x, a pure VSTest logger with no compile-time types), so the generated code can't see the type → CS0400.
2. Add compile back and you hit the real wall:
error CS1705: 'GitHubActionsTestLogger' 3.0.5 uses 'Microsoft.Testing.Platform 2.0.0'
which has a higher version than referenced assembly 'Microsoft.Testing.Platform 1.9.1'

Why 1.9.1 is pinned: our xunit.v3 3.2.2 (current stable) drags in the xunit.v3.core.mtp-v1 / xunit.v3.mtp-v1 packages, which pin Microsoft.Testing.Platform to 1.9.1. GHATL 3.x is built against MTP 2.0. Those can't coexist. So the update genuinely cannot work today — it's blocked upstream on xunit, not on anything we're doing wrong.

When it will be possible: xunit is mid-migration from MTP v1 → v2. The mtp-v2 variant only exists in xunit.v3 4.0.0-pre.* (confirmed 4.0.0-pre.154 installs xunit.v3.mtp-v2). There is no stable xunit.v3 on MTP 2.0 yet, and Microsoft.NET.Test.Sdk latest stable is still 18.8.1 (what we have). So GHATL 3.x becomes viable only once we move to xunit.v3 4.x (MTP 2.0), which is still prerelease.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/dependency-bot configuration only; no runtime or test code changes.
> 
> **Overview**
> Adds a **Dependabot ignore** for `GitHubActionsTestLogger` versions **≥ 3.0.0**, so daily NuGet update PRs stop proposing upgrades that cannot build today.
> 
> The inline comment documents why: GHATL 3.x targets **Microsoft.Testing.Platform 2.0**, while the repo stays on **xunit.v3 3.x** and **MTP 1.9.1** (via `Directory.Packages.props` at 2.4.1). Revisit when moving to **xunit.v3 4.x / MTP v2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d34dba8383e9ba5845e3fb45e4ae4abf95e2a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->