### PR TITLE
Update Redis 8.10 test image to custom-30445126297-debian

### DIFF
--- a/tests/dockers/.env.v8.10
+++ b/tests/dockers/.env.v8.10
@@ -2,4 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.10-rc2
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:custom-30445126297-debian


### PR DESCRIPTION
Pins the Redis 8.10 test environment to the custom client-libs-test image build.

## Changes
- `.env.v8.10`: use `redislabs/client-libs-test:custom-30445126297-debian` for the 8.10 test environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line test Docker image pin with no application or production code changes.
> 
> **Overview**
> Updates the **Redis 8.10** test env so `CLIENT_LIBS_TEST_IMAGE` points at `redislabs/client-libs-test:custom-30445126297-debian` instead of `8.10-rc2`.
> 
> That value is loaded from `tests/dockers/.env.v8.10` for the run-tests GitHub Action and drives the standalone/cluster images in `docker-compose.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c603a8471c1e1afec7f357d04e7c8bfb4235641c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->