### PR TITLE
Bump 8.10 test env to official 8.10.0 release

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
         fail-fast: false
         matrix:
           # Full version set runs only on the nightly schedule; PRs and pushes
-          # test a reduced set (7.2 LTS, 7.4 LTS, 8.2 LTS, 8.8 current stable, 8.10 - next) to keep CI fast.
+          # test a reduced set (7.2 LTS, 7.4 LTS, 8.2 LTS, 8.8, 8.10 current stable) to keep CI fast.
           redis-version: ${{ fromJSON(github.event_name == 'schedule'
             && '["8.10", "8.8", "8.6", "8.4", "8.2", "7.4", "7.2", "6.2"]'
             || '["8.10", "8.8", "8.2", "7.4", "7.2"]') }}

--- a/tests/dockers/.env.v8.10
+++ b/tests/dockers/.env.v8.10
@@ -2,4 +2,4 @@
 # Used by the run-tests GitHub Action
 
 # Redis CE image version (Redis 8+ includes modules natively)
-CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:custom-30445126297-debian
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:8.10.0

--- a/tests/dockers/docker-compose.yml
+++ b/tests/dockers/docker-compose.yml
@@ -3,7 +3,7 @@
 services:
 
   redis:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.10-rc2}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.10.0}
     container_name: redis-standalone
     environment:
       - TLS_ENABLED=yes
@@ -28,7 +28,7 @@ services:
       - all
 
   cluster:
-    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.10-rc2}
+    image: ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.10.0}
     container_name: redis-cluster
     environment:
       - REDIS_CLUSTER=yes


### PR DESCRIPTION
Replace the 8.10-rc2 custom image with the released redislabs/client-libs-test:8.10.0, including the compose fallback image tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and local docker test image pins only; no application or runtime behavior changes.
> 
> **Overview**
> **Switches Redis 8.10 integration test images** from `8.10-rc2` / a custom build tag to the released **`redislabs/client-libs-test:8.10.0`**.
> 
> Updates `tests/dockers/.env.v8.10` and the default image in `tests/dockers/docker-compose.yml` (standalone and cluster services). The integration workflow comment now labels **8.10** as current stable alongside the reduced PR/push Redis version matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f506cc5b2540fc66db2b3640f81ebaa0cc762932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->