### PR TITLE
Announce the library name without demanding IDatabase

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,10 @@
         <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
         <SuppressTfmSupportBuildErrors>true</SuppressTfmSupportBuildErrors>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <NoWarn>$(NoWarn);CS1591;NRS003</NoWarn>
+        <!-- SER007: StackExchange.Redis' retry API (WithRetry, RetryPolicy, CommandFlags.CommandRetry*) is
+             [Experimental]; we use it deliberately, and CommandCategories aliases the flags for the rest of
+             the library -->
+        <NoWarn>$(NoWarn);CS1591;NRS003;SER007</NoWarn>
         <IsWindows>$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::get_Windows())))</IsWindows>
     </PropertyGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <!-- primary library -->
     <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.10" />
-    <PackageVersion Include="StackExchange.Redis" Version="3.0.25" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.1.3" />
     <!-- tests, etc -->
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.7.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/src/NRedisStack/Auxiliary.cs
+++ b/src/NRedisStack/Auxiliary.cs
@@ -62,6 +62,18 @@ public static class Auxiliary
     {
         if (!_setInfo) return;
 
+        // ...but never through a transaction: commands there are not sent, they are added to the caller's
+        // MULTI/EXEC, so we would be quietly changing what their transaction contains - and nothing queued in
+        // a transaction can be waited on before EXEC without deadlocking (fire-and-forget dodges the wait,
+        // not the queueing). The latch is deliberately left set, so the next command that isn't part of a
+        // transaction announces instead.
+        //
+        // Tested at the async level to match the parameter: ITransaction : ITransactionAsync, so this covers
+        // the sync-capable transaction as well as the async-only one that CreateTransaction() hands back on a
+        // retry-wrapped database. (Neither is an IDatabase, which is why the cast this replaced could not work
+        // for either.)
+        if (db is ITransactionAsync) return;
+
         _setInfo = false; // one attempt only, successful or not
         var libraryName = _libraryName;
         if (libraryName == null) return;

--- a/src/NRedisStack/Auxiliary.cs
+++ b/src/NRedisStack/Auxiliary.cs
@@ -48,22 +48,61 @@ public static class Auxiliary
         return _db;
     }
 
-    internal static void SetInfoInPipeline(this IDatabase db)
+    /// <summary>
+    /// Announce the library name/version on first use, once per process.
+    /// </summary>
+    /// <remarks>
+    /// This takes <see cref="IDatabaseAsync"/> rather than <see cref="IDatabase"/> deliberately: an async-only
+    /// database (such as the retry wrapper from <c>WithRetry</c>) does not implement <see cref="IDatabase"/>, so
+    /// demanding the sync interface here would make every async command fail. The two commands are issued
+    /// fire-and-forget - they are enqueued ahead of the command that triggered this, and overlapped
+    /// fire-and-forget is well-defined - so nothing has to be awaited, and no batch is needed to group them.
+    /// </remarks>
+    internal static void SetLibraryInfoOnce(this IDatabaseAsync db)
     {
-        if (_setInfo)
+        if (!_setInfo) return;
+
+        _setInfo = false; // one attempt only, successful or not
+        var libraryName = _libraryName;
+        if (libraryName == null) return;
+
+        try
         {
-            _setInfo = false;
-            if (_libraryName == null) return;
-            Pipeline pipeline = new(db);
-            _ = pipeline.Db.ClientSetInfoAsync(SetInfoAttr.LibraryName, _libraryName);
-            _ = pipeline.Db.ClientSetInfoAsync(SetInfoAttr.LibraryVersion, GetNRedisStackVersion());
-            pipeline.Execute();
+            Observe(db.ClientSetInfoAsync(SetInfoAttr.LibraryName, libraryName, CommandFlags.FireAndForget));
+            Observe(db.ClientSetInfoAsync(SetInfoAttr.LibraryVersion, GetNRedisStackVersion(), CommandFlags.FireAndForget));
+        }
+        catch
+        {
+            // reporting who we are is never worth failing the caller's command over
+        }
+
+        static void Observe(Task pending)
+        {
+            // fire-and-forget should already have completed, on this thread, with nothing to observe;
+            // anything else is unexpected enough to be worth consuming, so that a failure cannot resurface
+            // later as an unobserved task exception unrelated to anything the caller did
+            if (!pending.IsCompletedSuccessfully)
+            {
+                _ = Awaited(pending);
+            }
+        }
+
+        static async Task Awaited(Task pending)
+        {
+            try
+            {
+                await pending.ConfigureAwait(false);
+            }
+            catch
+            {
+                // as above: best-effort
+            }
         }
     }
 
     public static RedisResult Execute(this IDatabase db, SerializedCommand command)
     {
-        db.SetInfoInPipeline();
+        db.SetLibraryInfoOnce();
         return db.Execute(command.Command, command.Args, flags: command.EffectiveFlags);
     }
 
@@ -74,9 +113,18 @@ public static class Auxiliary
 
     public static async Task<RedisResult> ExecuteAsync(this IDatabaseAsync db, SerializedCommand command)
     {
-        ((IDatabase)db).SetInfoInPipeline();
+        db.SetLibraryInfoOnce();
         return await db.ExecuteAsync(command.Command, command.Args, flags: command.EffectiveFlags);
     }
+
+    /// <summary>
+    /// Dispatch a command with additional flags beyond its category.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does not announce the library name: this overload exists for the announcement itself.
+    /// </remarks>
+    internal static Task<RedisResult> ExecuteAsync(this IDatabaseAsync db, SerializedCommand command, CommandFlags flags)
+        => db.ExecuteAsync(command.Command, command.Args, flags: command.EffectiveFlags | flags);
 
     internal static async Task<RedisResult> ExecuteAsync(this IServer server, int? db, SerializedCommand command)
     {

--- a/src/NRedisStack/CoreCommands/CoreCommandsAsync.cs
+++ b/src/NRedisStack/CoreCommands/CoreCommandsAsync.cs
@@ -13,15 +13,50 @@ public static class CoreCommandsAsync //: ICoreCommandsAsync
     /// <param name="value">the attribute value</param>
     /// <returns><see langword="true"/> if the attribute name was successfully set, Error otherwise.</returns>
     /// <remarks><seealso href="https://redis.io/commands/client-setinfo/"/></remarks>
-    public static async Task<bool> ClientSetInfoAsync(this IDatabaseAsync db, SetInfoAttr attr, string value)
+    public static Task<bool> ClientSetInfoAsync(this IDatabaseAsync db, SetInfoAttr attr, string value)
+        => db.ClientSetInfoAsync(attr, value, CommandFlags.None);
+
+    /// <inheritdoc cref="ClientSetInfoAsync(IDatabaseAsync, SetInfoAttr, string)"/>
+    /// <param name="db">the database to query</param>
+    /// <param name="attr">which attribute to set</param>
+    /// <param name="value">the attribute value</param>
+    /// <param name="flags">
+    /// Additional dispatch flags for this send. <see cref="CommandFlags.FireAndForget"/> discards the reply,
+    /// so there is nothing to report and the result is always <see langword="true"/>.
+    /// </param>
+    /// <remarks>
+    /// Internal because the flags here are a dispatch concern, not the command's category; the one-time
+    /// library-name announcement uses this to avoid making the caller's first command wait for a reply.
+    /// </remarks>
+    internal static Task<bool> ClientSetInfoAsync(this IDatabaseAsync db, SetInfoAttr attr, string value, CommandFlags flags)
     {
         var compareVersions = db.Multiplexer.GetServer(db.Multiplexer.GetEndPoints()[0]).Version.CompareTo(new(7, 1, 242));
         if (compareVersions < 0) // the server does not support the CLIENT SETNAME command
         {
-            return false;
+            return _completedFalse;
         }
-        return (await db.ExecuteAsync(CoreCommandBuilder.ClientSetInfo(attr, value))).OKtoBoolean();
+
+        var fireAndForget = (flags & CommandFlags.FireAndForget) != 0;
+        var pending = db.ExecuteAsync(CoreCommandBuilder.ClientSetInfo(attr, value), flags);
+        if (fireAndForget && pending.IsCompletedSuccessfully)
+        {
+            // the expected fire-and-forget path: no reply to interpret and nothing left pending, so the
+            // async machinery is not involved at all
+            return _completedTrue;
+        }
+
+        // interpreting the reply is the only part that needs a state machine; a fire-and-forget send that
+        // did *not* complete synchronously is unexpected, and lands here so that a failure is not dropped
+        return Awaited(pending, fireAndForget);
+
+        static async Task<bool> Awaited(Task<RedisResult> pending, bool fireAndForget)
+        {
+            var result = await pending.ConfigureAwait(false);
+            return fireAndForget || result.OKtoBoolean();
+        }
     }
+
+    private static readonly Task<bool> _completedTrue = Task.FromResult(true), _completedFalse = Task.FromResult(false);
 
     /// <summary>
     /// The BZMPOP command.

--- a/src/NRedisStack/Pipeline.cs
+++ b/src/NRedisStack/Pipeline.cs
@@ -6,7 +6,7 @@ public class Pipeline
 {
     public Pipeline(IDatabase db)
     {
-        db.SetInfoInPipeline();
+        db.SetLibraryInfoOnce();
         _batch = db.CreateBatch();
     }
 

--- a/src/NRedisStack/RedisStackCommands/CommandCategories.cs
+++ b/src/NRedisStack/RedisStackCommands/CommandCategories.cs
@@ -8,10 +8,10 @@ namespace NRedisStack.RedisStackCommands;
 /// </summary>
 /// <remarks>
 /// <para>
-/// These mirror the <c>CommandFlags.CommandRetry*</c> members added in StackExchange.Redis 3.1.0, but are
-/// declared here as casts so that NRedisStack can keep a 3.0.x floor: on older versions the bits fall
-/// outside the library's user-selectable mask and are silently discarded, which reproduces today's
-/// behaviour exactly. <c>ServerSpecific</c> is accepted by 3.1.0 but is not named on its public enum.
+/// The rungs are aliases for the <c>CommandFlags.CommandRetry*</c> members, so that the categories carry
+/// names that describe the command rather than the retry mechanism, and so that the documentation below has
+/// somewhere to live. <c>ServerSpecific</c> is honoured by StackExchange.Redis but is not named on its
+/// public enum, so that one is still a bit.
 /// </para>
 /// <para>
 /// The ladder runs from least to most side-effecting; a retry policy specifies the most side-effecting
@@ -22,19 +22,19 @@ namespace NRedisStack.RedisStackCommands;
 internal static class CommandCategories
 {
     /// <summary>Always safe to replay, regardless of connection or server state.</summary>
-    internal const CommandFlags Always = (CommandFlags)(1 << 13);
+    internal const CommandFlags Always = CommandFlags.CommandRetryAlways;
 
     /// <summary>Connection-level metadata, e.g. <c>CLIENT SETINFO</c>.</summary>
-    internal const CommandFlags Connection = (CommandFlags)(4 << 13);
+    internal const CommandFlags Connection = CommandFlags.CommandRetryConnection;
 
     /// <summary>Pure read; replay observes state but does not change it.</summary>
-    internal const CommandFlags ReadOnly = (CommandFlags)(8 << 13);
+    internal const CommandFlags ReadOnly = CommandFlags.CommandRetryReadOnly;
 
     /// <summary>Conditional write; a replay is checked against server state and rejected.</summary>
-    internal const CommandFlags WriteChecked = (CommandFlags)(12 << 13);
+    internal const CommandFlags WriteChecked = CommandFlags.CommandRetryWriteChecked;
 
     /// <summary>Unconditional overwrite; a replay lands on the same value (last-writer-wins).</summary>
-    internal const CommandFlags WriteLastWins = (CommandFlags)(16 << 13);
+    internal const CommandFlags WriteLastWins = CommandFlags.CommandRetryWriteLastWins;
 
     /// <summary>Cumulative write; a replay double-applies and changes the result.</summary>
     /// <remarks>
@@ -48,10 +48,10 @@ internal static class CommandCategories
     /// raises the ceiling, while still allowing the known-never-sent replay (see <see cref="Never"/>),
     /// which is the case that matters for riding out <c>-LOADING</c> during setup.
     /// </remarks>
-    internal const CommandFlags WriteAccumulating = (CommandFlags)(20 << 13);
+    internal const CommandFlags WriteAccumulating = CommandFlags.CommandRetryWriteAccumulating;
 
     /// <summary>Server administration, e.g. <c>FT.CONFIG SET</c>.</summary>
-    internal const CommandFlags ServerAdmin = (CommandFlags)(24 << 13);
+    internal const CommandFlags ServerAdmin = CommandFlags.CommandRetryServerAdmin;
 
     /// <summary>Never replay, under any policy.</summary>
     /// <remarks>
@@ -61,7 +61,7 @@ internal static class CommandCategories
     /// far as <c>Never</c> itself. Use it where a replay would corrupt state or report a spurious error
     /// even though the original attempt succeeded, and where forgoing retry entirely is the lesser cost.
     /// </remarks>
-    internal const CommandFlags Never = (CommandFlags)(31 << 13);
+    internal const CommandFlags Never = CommandFlags.CommandRetryNever;
 
     /// <summary>
     /// The command is bound to a particular endpoint (typically because it carries a server-side cursor

--- a/src/NRedisStack/TaskPolyfills.cs
+++ b/src/NRedisStack/TaskPolyfills.cs
@@ -1,0 +1,16 @@
+// ReSharper disable once CheckNamespace
+namespace System.Threading.Tasks;
+
+#if !NET // modern .NET has this on Task itself; NS/NETFX do not
+internal static class TaskPolyfills
+{
+    extension(Task task)
+    {
+        /// <summary>
+        /// Gets whether the task completed successfully, as opposed to faulting, being cancelled, or still
+        /// being pending.
+        /// </summary>
+        public bool IsCompletedSuccessfully => task.Status == TaskStatus.RanToCompletion;
+    }
+}
+#endif

--- a/src/NRedisStack/Transactions.cs
+++ b/src/NRedisStack/Transactions.cs
@@ -9,7 +9,7 @@ public class Transaction
 
     public Transaction(IDatabase db)
     {
-        db.SetInfoInPipeline();
+        db.SetLibraryInfoOnce();
         _transaction = db.CreateTransaction();
     }
 

--- a/tests/Doc/Doc.csproj
+++ b/tests/Doc/Doc.csproj
@@ -18,8 +18,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <!-- must track NRedisStack.Tests, which overrides ahead of the library floor; see the note there -->
-        <PackageReference Include="StackExchange.Redis" VersionOverride="3.1.0"/>
+        <PackageReference Include="StackExchange.Redis"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\NRedisStack\NRedisStack.csproj"/>

--- a/tests/NRedisStack.Tests/CommandCategoryTests.cs
+++ b/tests/NRedisStack.Tests/CommandCategoryTests.cs
@@ -13,27 +13,15 @@ namespace NRedisStack.Tests;
 /// </summary>
 public class CommandCategoryTests
 {
-    // NRedisStack keeps a StackExchange.Redis 3.0.x floor, so CommandCategories declares these as casts
-    // rather than referencing the (3.1.0+) named members. That only stays correct while the numbers agree,
-    // and a silent renumbering upstream would silently re-categorize every command we issue - so pin it.
-    // The test project deliberately overrides to 3.1.0 so the named members are available here.
-    [Theory]
-    [InlineData(CommandCategories.Always, CommandFlags.CommandRetryAlways)]
-    [InlineData(CommandCategories.Connection, CommandFlags.CommandRetryConnection)]
-    [InlineData(CommandCategories.ReadOnly, CommandFlags.CommandRetryReadOnly)]
-    [InlineData(CommandCategories.WriteChecked, CommandFlags.CommandRetryWriteChecked)]
-    [InlineData(CommandCategories.WriteLastWins, CommandFlags.CommandRetryWriteLastWins)]
-    [InlineData(CommandCategories.WriteAccumulating, CommandFlags.CommandRetryWriteAccumulating)]
-    [InlineData(CommandCategories.ServerAdmin, CommandFlags.CommandRetryServerAdmin)]
-    [InlineData(CommandCategories.Never, CommandFlags.CommandRetryNever)]
-    public void CategoryMatchesStackExchangeRedis(CommandFlags ours, CommandFlags theirs)
-        => Assert.Equal(theirs, ours);
-
-    // Message.CommandServerSpecific is internal to StackExchange.Redis, so there is no named member to
-    // compare against; assert the bit position instead, which is what their mask actually tests.
+    // The rungs are aliases of the CommandFlags.CommandRetry* members, so there is nothing left to compare
+    // them against. What still needs pinning is the numbering the masks assume, and the one value with no
+    // named member: Message.CommandServerSpecific is internal to StackExchange.Redis, so ServerSpecific is
+    // ours to keep aligned with the bit their mask actually tests.
     [Fact]
     public void ServerSpecificIsBit18() => Assert.Equal(1 << 18, (int)CommandCategories.ServerSpecific);
 
+    // consequently this also pins that the rung ladder still occupies bits 13-17 upstream: a renumbering
+    // there would move Never, and every masking decision built on it
     [Fact]
     public void MaskCoversTheCategoryRegionAndServerSpecificOnly()
         => Assert.Equal((31 << 13) | (1 << 18), (int)CommandCategories.Mask);

--- a/tests/NRedisStack.Tests/NRedisStack.Tests.csproj
+++ b/tests/NRedisStack.Tests/NRedisStack.Tests.csproj
@@ -9,10 +9,6 @@
              instead of the current (double, double) API, the build fails. Existing tests that deliberately
              exercise obsolete members opt in per-file with `#pragma warning disable CS0612, CS0618`. -->
         <WarningsAsErrors>$(WarningsAsErrors);CS0612;CS0618</WarningsAsErrors>
-
-        <!-- CommandCategoryTests asserts our cast-from-int categories still line up with the named
-             StackExchange.Redis members; those are [Experimental] under SER007 -->
-        <NoWarn>$(NoWarn);SER007</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -36,10 +32,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <!-- deliberately ahead of the library's floor: NRedisStack still builds against 3.0.x (where the
-             retry-category bits are simply masked off), but the tests need the named CommandRetry* members
-             in order to verify our cast-from-int values against them -->
-        <PackageReference Include="StackExchange.Redis" VersionOverride="3.1.0"/>
+        <PackageReference Include="StackExchange.Redis"/>
         <PackageReference Include="xunit.v3"/>
         <PackageReference Include="BouncyCastle.Cryptography"/>
         <PackageReference Include="Microsoft.Azure.StackExchangeRedis"/>

--- a/tests/NRedisStack.Tests/WithRetryTests.cs
+++ b/tests/NRedisStack.Tests/WithRetryTests.cs
@@ -42,6 +42,71 @@ public class WithRetryTests(EndpointsFixture endpointsFixture) : AbstractNRedisS
         Assert.Contains($"lib-name=NRedisStack(.NET_v{Environment.Version}) lib-ver={GetNRedisStackVersion()}", info);
     }
 
+    // a retry-wrapped transaction is the same trap again: statically just an ITransactionAsync, and not an
+    // IDatabase however it is tested. Kept alongside the announcement test below, because this half - the
+    // command working at all - must stay green regardless of what the guard there recognizes.
+    [SkipIfRedisTheory(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [MemberData(nameof(EndpointsFixture.Env.StandaloneOnly), MemberType = typeof(EndpointsFixture.Env))]
+    public async Task ModuleCommandsWorkOnRetryWrappedTransaction(string endpointId)
+    {
+        ResetInfoDefaults(); // demonstrate first connection
+        var db = GetCleanDatabase(endpointId);
+
+        var transaction = db.WithRetry(RetryPolicy.Default).CreateTransaction();
+        var json = new JsonCommandsAsync(transaction);
+
+        var pending = json.SetAsync("retry-tran-json", "$", "{\"Age\":23}");
+        Assert.True(await transaction.ExecuteAsync());
+        Assert.True(await pending);
+    }
+
+    // the announcement must not be queued into someone else's MULTI/EXEC: that changes what their transaction
+    // contains, and anything waiting on a queued reply before EXEC deadlocks
+    [SkipIfRedisTheory(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [MemberData(nameof(EndpointsFixture.Env.StandaloneOnly), MemberType = typeof(EndpointsFixture.Env))]
+    public Task TransactionsDoNotCarryTheAnnouncement(string endpointId)
+    {
+        var db = FirstUseDatabase(endpointId);
+        return AssertTransactionCarriesNoAnnouncement(db, db.CreateTransaction(), "tran-json");
+    }
+
+    // the same standard for the retry-wrapped shape, which the guard recognizes as an ITransactionAsync -
+    // the form CreateTransaction() actually advertises there, and the one that cannot stop being true.
+    [SkipIfRedisTheory(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [MemberData(nameof(EndpointsFixture.Env.StandaloneOnly), MemberType = typeof(EndpointsFixture.Env))]
+    public Task RetryWrappedTransactionsDoNotCarryTheAnnouncement(string endpointId)
+    {
+        var db = FirstUseDatabase(endpointId);
+        return AssertTransactionCarriesNoAnnouncement(db,
+            db.WithRetry(RetryPolicy.Default).CreateTransaction(), "retry-tran-announce-json");
+    }
+
+    // ITransaction and the retry-wrapped transaction have ITransactionAsync in common, so both shapes are
+    // held to the same standard here
+    private async Task AssertTransactionCarriesNoAnnouncement(IDatabase db, ITransactionAsync transaction, RedisKey key)
+    {
+        var pending = new JsonCommandsAsync(transaction).SetAsync(key, "$", "{\"Age\":23}");
+        Assert.True(await transaction.ExecuteAsync());
+        Assert.True(await pending);
+
+        var info = (await db.ExecuteAsync("CLIENT", "INFO")).ToString();
+        Assert.DoesNotContain("lib-name=NRedisStack", info);
+
+        // the announcement is still owed, so the next command outside a transaction performs it
+        await db.ExecuteAsync(new SerializedCommand(CommandCategories.Always, "PING"));
+
+        info = (await db.ExecuteAsync("CLIENT", "INFO")).ToString();
+        Assert.Contains($"lib-name=NRedisStack(.NET_v{Environment.Version}) lib-ver={GetNRedisStackVersion()}", info);
+    }
+
+    // a connection of our own, with the announcement still owed: these tests assert on the *absence* of our
+    // lib-name, so the connection must not be a shared one that has already announced
+    private IDatabase FirstUseDatabase(string endpointId)
+    {
+        ResetInfoDefaults(); // demonstrate first connection
+        return GetConnection(endpointId, shareConnection: false).GetDatabase();
+    }
+
     // the announcement relies on this: fire-and-forget must not leave the caller's first command waiting on
     // a reply, so the task it hands back is expected to be complete before we ever look at it
     [SkipIfRedisTheory(Is.Enterprise, Comparison.LessThan, "7.1.242")]

--- a/tests/NRedisStack.Tests/WithRetryTests.cs
+++ b/tests/NRedisStack.Tests/WithRetryTests.cs
@@ -1,0 +1,58 @@
+using NRedisStack.Core;
+using NRedisStack.RedisStackCommands;
+using StackExchange.Redis;
+using StackExchange.Redis.Availability;
+using Xunit;
+using static NRedisStack.Auxiliary;
+
+namespace NRedisStack.Tests;
+
+/// <summary>
+/// The retry-wrapped database from <c>WithRetry</c> is <see cref="IDatabaseAsync"/> only - it does not
+/// implement <see cref="IDatabase"/> - so anything on our async path that reaches for the sync interface
+/// breaks every command issued through it, before the command is even sent.
+/// </summary>
+public class WithRetryTests(EndpointsFixture endpointsFixture) : AbstractNRedisStackTest(endpointsFixture)
+{
+    [SkipIfRedisTheory(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [MemberData(nameof(EndpointsFixture.Env.StandaloneOnly), MemberType = typeof(EndpointsFixture.Env))]
+    public async Task ModuleCommandsWorkOnRetryWrappedDatabase(string endpointId)
+    {
+        ResetInfoDefaults(); // demonstrate first connection: the announcement used to demand IDatabase
+        var db = GetCleanDatabase(endpointId);
+
+        var json = new JsonCommandsAsync(db.WithRetry(RetryPolicy.Default));
+
+        Assert.True(await json.SetAsync("retry-json", "$", "{\"Name\":\"Shachar\",\"Age\":23}"));
+        Assert.Equal("{\"Name\":\"Shachar\",\"Age\":23}", (await json.GetAsync("retry-json")).ToString());
+    }
+
+    [SkipIfRedisTheory(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [MemberData(nameof(EndpointsFixture.Env.StandaloneOnly), MemberType = typeof(EndpointsFixture.Env))]
+    public async Task LibraryInfoIsAnnouncedThroughAnAsyncOnlyDatabase(string endpointId)
+    {
+        ResetInfoDefaults(); // demonstrate first connection
+        var db = GetCleanDatabase(endpointId);
+        IDatabaseAsync retrying = db.WithRetry(RetryPolicy.Default);
+
+        // the announcement is fire-and-forget, but it is enqueued ahead of this command, on this connection
+        await retrying.ExecuteAsync(new SerializedCommand(CommandCategories.Always, "PING"));
+
+        var info = db.Execute("CLIENT", "INFO").ToString();
+        Assert.Contains($"lib-name=NRedisStack(.NET_v{Environment.Version}) lib-ver={GetNRedisStackVersion()}", info);
+    }
+
+    // the announcement relies on this: fire-and-forget must not leave the caller's first command waiting on
+    // a reply, so the task it hands back is expected to be complete before we ever look at it
+    [SkipIfRedisTheory(Is.Enterprise, Comparison.LessThan, "7.1.242")]
+    [MemberData(nameof(EndpointsFixture.Env.StandaloneOnly), MemberType = typeof(EndpointsFixture.Env))]
+    public void FireAndForgetClientSetInfoCompletesSynchronously(string endpointId)
+    {
+        IDatabaseAsync retrying = GetDatabase(endpointId).WithRetry(RetryPolicy.Default);
+
+        var pending = retrying.ClientSetInfoAsync(SetInfoAttr.LibraryName, "TestLibraryName", CommandFlags.FireAndForget);
+
+        Assert.Equal(TaskStatus.RanToCompletion, pending.Status);
+        Assert.True(pending.Result); // fire-and-forget: nothing to report, so never a false negative
+    }
+}


### PR DESCRIPTION
(specifically: support WithRetry)

Note: takes SE.Redis 3.1.3

Auxiliary.ExecuteAsync unconditionally cast its IDatabaseAsync to IDatabase in order to send the one-time CLIENT SETINFO lib-name/lib-ver pair. A retry-wrapped database (SE.Redis 3.1.0 WithRetry) is async-only - RetryDatabase implements IDatabaseAsync but not IDatabase - so every async module command issued through one threw InvalidCastException before the command was sent, making the retry categories added in #540 unusable from the async API.

The announcement never needed the sync interface: it only needed it to create a batch to group the two commands, which don't need grouping. It is now typed as IDatabaseAsync and dispatched fire-and-forget via an internal ClientSetInfoAsync overload that takes dispatch flags, so there is no cast, no batch, and no round-trip on the caller's first command. In the expected case - fire-and-forget completing synchronously - no state machine is entered on this path at all: the overload hands back a cached completed task, and the caller only awaits (to consume a fault) if a task somehow comes back not-yet-completed. A synchronous failure in the version probe can no longer fail the caller's command either; announcing who we are is best-effort.

Renamed SetInfoInPipeline -> SetLibraryInfoOnce (internal): there is no longer a pipeline involved.

Task.IsCompletedSuccessfully only exists on modern .NET, so netstandard2.0/net481 get it as an extension property polyfill rather than open-coding the Status test at each site.

Audited the rest of the library for the same shape: this was the only unconditional cast to a sync SE.Redis interface; SearchCommandsAsync's cluster cursor path was already type-tested.

Tests cover an async module command and the first-use announcement over db.WithRetry(...) - both fail with InvalidCastException before this change - plus the synchronous completion that the fire-and-forget dispatch relies on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-command behavior on every connection and transaction edge cases for library announcement; dependency bump to experimental WithRetry APIs affects all consumers.
> 
> **Overview**
> Fixes async module commands on **`db.WithRetry(...)`** by removing the **`IDatabase`** cast in the one-time **CLIENT SETINFO** announcement. **`SetLibraryInfoOnce`** (renamed from `SetInfoInPipeline`) runs on **`IDatabaseAsync`**, sends lib-name/lib-ver as **fire-and-forget** (no batch, no extra round-trip on the caller’s first command), and **skips `ITransactionAsync`** so SETINFO is not queued into MULTI/EXEC; announcement failures are best-effort.
> 
> Adds an internal **`ClientSetInfoAsync(..., CommandFlags)`** fast path for synchronous fire-and-forget completion, a **`Task.IsCompletedSuccessfully`** polyfill for netstandard/net481, and **`WithRetryTests`** for retry DB/transactions and transaction announcement behavior.
> 
> **Dependency:** StackExchange.Redis **3.0.25 → 3.1.3**; **`CommandCategories`** now aliases **`CommandFlags.CommandRetry*`** (drops int casts); **SER007** suppressed repo-wide; test projects use central package version (no 3.1.0 override).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f3a6962a270c8995efa6ce3c61c9719cba44e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->