### PR TITLE
Bump StackExchange.Redis from 3.1.13 to 3.1.31

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <!-- primary library -->
     <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.11" />
-    <PackageVersion Include="StackExchange.Redis" Version="3.1.13" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.1.31" />
     <!-- tests, etc -->
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.7.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />


### PR DESCRIPTION
Routine bump of the core dependency, with the analyzer surface as the motivation.

 3.1.31 adds four new analyzer rules over 3.1.13:

 - SER305 - awaiting a queued command before Execute, which will never complete
 - SER306 - awaiting a fire-and-forget result, which yields nothing
 - SER307 - blocking on a redis call instead of awaiting it
 - SER308 - blocking on a task through the library's Wait helpers

 It also ships a StackExchange.Redis.CodeFixes.dll alongside the existing analyzer assembly, so some of these come with fixes attached.

 None of the new rules fire here: the build is clean, 0 warnings, 0 errors, across net481 / netstandard2.0 / net6.0 / net8.0 / net10.0 plus the test and Doc projects. Verified the analyzer is actually loaded and reporting rather than silently absent - a throwaway probe project on 3.1.31 does produce SER307 for db.StringGetAsync(...).Result. The .Result uses in our tests don't trip it because they go through a local rather than being applied to the invocation directly.

 Also rebuilt with every SER3xx escalated to warning (they are not all warning-by-default) - still nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency bump only; no application code or API surface changes in this repo.
> 
> **Overview**
> Bumps the central `StackExchange.Redis` package version from **3.1.13** to **3.1.31** in `Directory.Packages.props`.
> 
> The newer package adds analyzer rules SER305–SER308 (mis-await / blocking Redis usage) plus code fixes. No other files change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56459a048683c0f55d65b212b1bfebdc02cb5712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->